### PR TITLE
feat(core): strict composable service authoring dx with fragments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -145,7 +145,7 @@ With each commit, review and update pending changesets accordingly.
 Changesets must be written with the package consumer in mind, telling them what they need to know about changes, not just what changed.
 Packages are released manually via GitHub UI, not automatically.
 
-Terminology note for strict composable partial-service authoring: use **mixins** as the primary term (formerly **fragments**).
+Terminology note for strict composable partial-service authoring: use **fragments** as the primary term.
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -145,6 +145,8 @@ With each commit, review and update pending changesets accordingly.
 Changesets must be written with the package consumer in mind, telling them what they need to know about changes, not just what changed.
 Packages are released manually via GitHub UI, not automatically.
 
+Terminology note for strict composable partial-service authoring: use **mixins** as the primary term (formerly **fragments**).
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,10 @@ bd close bd-42 --reason "Completed" --json
 1. **Check ready work**: `bd ready` shows unblocked issues
 2. **Claim your task atomically**: `bd update <id> --claim`
 3. **Work on it**: Implement, test, document
-4. **Discover new work?** Create linked issue:
+4. **Terminology for strict composable partial-service authoring**: use **mixins** as the primary term (formerly **fragments**)
+5. **Discover new work?** Create linked issue:
    - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
-5. **Complete**: `bd close <id> --reason "Done"`
+6. **Complete**: `bd close <id> --reason "Done"`
 
 ### Quality
 - Use `--acceptance` and `--design` fields when creating issues

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ bd close bd-42 --reason "Completed" --json
 1. **Check ready work**: `bd ready` shows unblocked issues
 2. **Claim your task atomically**: `bd update <id> --claim`
 3. **Work on it**: Implement, test, document
-4. **Terminology for strict composable partial-service authoring**: use **mixins** as the primary term (formerly **fragments**)
+4. **Terminology for strict composable partial-service authoring**: use **fragments** as the primary term
 5. **Discover new work?** Create linked issue:
    - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
 6. **Complete**: `bd close <id> --reason "Done"`

--- a/README.md
+++ b/README.md
@@ -1,79 +1,86 @@
 # SCOMP
 
-RPC experiment
+Typed service contract + transport toolkit.
 
-## Concepts
+## Default authoring model (strict + grouped)
 
-- Unary
+SCOMP now defaults to **strict, grouped service authoring** with three operation sections:
 
-### Terminology
+- `requests`
+- `signals`
+- `feeds`
 
-For the strict composable partial-service authoring work, use **fragments** as the primary term.
+Use `createScompService` to define a full service. In strict mode, every contract method must be implemented and grouped under the correct section.
 
-service()
+```ts
+import { createScompService } from '@scomp/core';
 
-## Usage
+interface UsersContract {
+  getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+  notifyLogin(input: { id: number; at: string }): Promise<void>;
+  liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
+}
 
-```javascript
-  const scomp = new Scomp(new SocketIOWire(io));
-  const client = scomp.client();
+const usersService = createScompService<UsersContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id, name: `user-${id}` })
+  },
+  signals: {
+    notifyLogin: async ({ id, at }) => {
+      console.log('login', { id, at });
+    }
+  },
+  feeds: {
+    liveUsers: {
+      strategy: 'fanout',
+      handler: async function* () {
+        yield { id: 1 };
+      }
+    }
+  }
+});
+```
 
-  // void result function
-  scomp.call(client.saft.get('console').log('Hey ho!'));
+## Fragment composition flow
 
-  // void result function ($ always initiates a call, or rename to then to be more promise like)
-  client.saft.get('console').log('Hey ho!').$();
+Use **fragments** for partial/domain-local implementation, then compose them with `composeScompFragments`.
 
-  // return from promise
-  client.viewdb.collection('order').findByPromise({}).$()
-    .then(console.log);
-  // shortcut to just use .then() <-- trigger call
-  client.viewdb.collection('order').findByPromise({})
-    .then(console.log);
+```ts
+import { createScompFragment, composeScompFragments } from '@scomp/core';
 
-// return stream
-  client.viewdb.collection('order').find({}).toArray(scomp.callback()).$()
-    .on('data', data=>{}) // data element
-    .on('end', ()=>{}) // other side terminated stream
-    ;  
-  ```
+const usersRequests = createScompFragment<UsersContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id, name: `user-${id}` })
+  }
+});
+
+const usersSignals = createScompFragment<UsersContract>('users').implement({
+  signals: {
+    notifyLogin: async () => {
+      return;
+    }
+  }
+});
+
+const usersFeeds = createScompFragment<UsersContract>('users').implement({
+  feeds: {
+    liveUsers: async function* () {
+      yield { id: 1 };
+    }
+  }
+});
+
+const usersRouterFragment = composeScompFragments(usersRequests, usersSignals, usersFeeds);
+```
+
+Fragment composition rejects duplicate methods across fragments.
+
+## Demo
+
+See `apps/demo` for end-to-end examples using grouped sections and fragments.
 
 ## Wire format
 
-Current protocol reference for the new transport stack:
-- See [docs/transport-json-protocol.md](docs/transport-json-protocol.md)
+Transport protocol reference:
 
-### Request Client -> Server
-
-```json
-{
-  "id": 123123121,
-  "req": {
-    "s": "saft",
-    "p":[ "eh", "oh"]
-  }
-}
-```
-
-### Response Server -> Client
-
-```json
-{
-  "id": 123123121, // corresponds to
-  "res": {}, // user data
-  "str": {}, // stream control data
-  "err": {} // error
-}
-```
-
-### Stream Control (Most commony Server -> Client)
-
-```json
-{
-  "id": 123123123, // corresponds to
-  "seq": 0, // sequence of events, start at 0
-  "res": {}, // user data
-  "str": {}, // stream control data
-  "err": {} // error
-}
-```
+- [docs/transport-json-protocol.md](docs/transport-json-protocol.md)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ RPC experiment
 
 - Unary
 
+### Terminology
+
+For the strict composable partial-service authoring work, use **mixins** as the primary term (formerly called **fragments**).
+
 service()
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RPC experiment
 
 ### Terminology
 
-For the strict composable partial-service authoring work, use **mixins** as the primary term (formerly called **fragments**).
+For the strict composable partial-service authoring work, use **fragments** as the primary term.
 
 service()
 

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -1,0 +1,28 @@
+# @scomp/demo
+
+This demo shows the default SCOMP authoring flow:
+
+- strict grouped service implementation via `createScompService`
+- partial domain implementations via `createScompFragment`
+- fragment composition via `composeScompFragments`
+
+## Authoring model
+
+`apps/demo/backend/server.ts` includes both forms:
+
+1. `usersService`: strict grouped service with required sections:
+   - `requests`
+   - `signals`
+   - `feeds`
+2. `usersRequestsFragment`, `usersSignalsFragment`, `usersFeedsFragment`: partial fragments
+3. `usersComposedFragment`: composed fragment router used by the running demo server
+
+Both produce equivalent route kinds for the same contract methods.
+
+## Run
+
+```bash
+bun turbo run start --filter=@scomp/demo
+```
+
+Requires RabbitMQ at `SCOMP_RABBITMQ_URL` (defaults to `amqp://localhost:5672`).

--- a/apps/demo/backend/server.ts
+++ b/apps/demo/backend/server.ts
@@ -1,57 +1,128 @@
-import { createScompService, type CompiledRouter } from '@scomp/core';
+import {
+  composeScompFragments,
+  createScompFragment,
+  createScompService,
+  type CompiledRouter,
+} from '@scomp/core';
 import { createRabbitMqTransport, type RabbitMQTransportConfig } from '@scomp/transport-rabbitmq';
 import type { DemoApiContract, LiveTickerInput, LiveTickerTick } from '../shared/api.contract';
 
-const usersService = createScompService<DemoApiContract['users']>('users').implement({
-  getUser: {
-    kind: 'request',
-    parser: (payload): { id: number } => {
-      const input = payload as { id: number };
-      return { id: Number(input.id) };
-    },
-    handler: async (input) => ({
-      id: input.id,
-      name: `user-${input.id}`
-    })
-  },
-  notifyLogin: {
-    kind: 'signal',
-    parser: (payload): { userId: number; at: string } => {
-      const input = payload as { userId: number; at: string };
-      return {
-        userId: Number(input.userId),
-        at: String(input.at)
-      };
-    },
-    handler: async (input) => {
-      console.log(`[signal] user login notified`, input);
+export const usersService = createScompService<DemoApiContract['users']>('users').implement({
+  requests: {
+    getUser: {
+      parser: (payload): { id: number } => {
+        const input = payload as { id: number };
+        return { id: Number(input.id) };
+      },
+      handler: async (input) => ({
+        id: input.id,
+        name: `user-${input.id}`
+      })
     }
   },
-  liveTicker: {
-    kind: 'feed',
-    strategy: 'fanout',
-    hashKey: (input: LiveTickerInput) => input.channel,
-    handler: async function* (input: LiveTickerInput): AsyncIterable<LiveTickerTick> {
-      let sequence = 0;
-      try {
-        while (true) {
-          sequence += 1;
-          await new Promise((resolve) => setTimeout(resolve, 500));
-          yield {
-            channel: input.channel,
-            sequence,
-            at: new Date().toISOString()
-          };
+  signals: {
+    notifyLogin: {
+      parser: (payload): { userId: number; at: string } => {
+        const input = payload as { userId: number; at: string };
+        return {
+          userId: Number(input.userId),
+          at: String(input.at)
+        };
+      },
+      handler: async (input) => {
+        console.log(`[signal] user login notified`, input);
+      }
+    }
+  },
+  feeds: {
+    liveTicker: {
+      strategy: 'fanout',
+      hashKey: (input: LiveTickerInput) => input.channel,
+      handler: async function* (input: LiveTickerInput): AsyncIterable<LiveTickerTick> {
+        let sequence = 0;
+        try {
+          while (true) {
+            sequence += 1;
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            yield {
+              channel: input.channel,
+              sequence,
+              at: new Date().toISOString()
+            };
+          }
+        } finally {
+          console.log(`[feed] teardown for channel`, input.channel);
         }
-      } finally {
-        console.log(`[feed] teardown for channel`, input.channel);
       }
     }
   }
 });
 
+export const usersRequestsFragment = createScompFragment<DemoApiContract['users']>('users').implement({
+  requests: {
+    getUser: {
+      parser: (payload): { id: number } => {
+        const input = payload as { id: number };
+        return { id: Number(input.id) };
+      },
+      handler: async (input) => ({
+        id: input.id,
+        name: `user-${input.id}`
+      })
+    }
+  }
+});
+
+export const usersSignalsFragment = createScompFragment<DemoApiContract['users']>('users').implement({
+  signals: {
+    notifyLogin: {
+      parser: (payload): { userId: number; at: string } => {
+        const input = payload as { userId: number; at: string };
+        return {
+          userId: Number(input.userId),
+          at: String(input.at)
+        };
+      },
+      handler: async (input) => {
+        console.log(`[signal] user login notified`, input);
+      }
+    }
+  }
+});
+
+export const usersFeedsFragment = createScompFragment<DemoApiContract['users']>('users').implement({
+  feeds: {
+    liveTicker: {
+      strategy: 'fanout',
+      hashKey: (input: LiveTickerInput) => input.channel,
+      handler: async function* (input: LiveTickerInput): AsyncIterable<LiveTickerTick> {
+        let sequence = 0;
+        try {
+          while (true) {
+            sequence += 1;
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            yield {
+              channel: input.channel,
+              sequence,
+              at: new Date().toISOString()
+            };
+          }
+        } finally {
+          console.log(`[feed] teardown for channel`, input.channel);
+        }
+      }
+    }
+  }
+});
+
+export const usersComposedFragment = composeScompFragments(
+  usersRequestsFragment,
+  usersSignalsFragment,
+  usersFeedsFragment
+);
+
 export function getDemoRouter(): CompiledRouter {
-  return usersService.router;
+  return usersComposedFragment.router;
 }
 
 export async function startDemoServer(config: RabbitMQTransportConfig) {

--- a/apps/demo/run.ts
+++ b/apps/demo/run.ts
@@ -1,7 +1,10 @@
-import { startDemoServer } from './backend/server';
+import { startDemoServer, usersComposedFragment, usersService } from './backend/server';
 import { createDemoClient } from './frontend/client';
 
 async function runDemo() {
+  console.log('strict service routes:', Object.keys(usersService.router).sort());
+  console.log('composed fragment routes:', Object.keys(usersComposedFragment.router).sort());
+
   const rabbitConfig = {
     url: process.env.SCOMP_RABBITMQ_URL ?? 'amqp://localhost:5672',
     prefetch: 20

--- a/apps/demo/src/index.ts
+++ b/apps/demo/src/index.ts
@@ -1,52 +1,57 @@
-import {
-  createScompClient,
-  createScompFeed,
-  createLegacyScompService,
-} from "@scomp/core";
-import { createInprocessTransport } from "@scomp/transport-inprocess";
+import { composeScompFragments, createScompFragment, createScompService } from '@scomp/core';
 
-/**
- * Runs a local demo showcasing request, feed, and command service methods.
- */
-async function main() {
-  const service = createLegacyScompService()
-    .request("sum", async (left: number, right: number) => left + right)
-    .feed("countTo", async function* (limit: number) {
-      for (let value = 1; value <= limit; value += 1) {
-        yield value;
-      }
-    })
-    .feed("watch", () => {
-      const feed = createScompFeed<number>();
-      queueMicrotask(() => {
-        feed.next(42).complete();
-      });
-      return feed;
-    })
-    .command("log", (message: string): void => {
-      console.log("command:", message);
-    })
-    .build();
-
-  const transport = createInprocessTransport(service);
-  const client = createScompClient(service, transport);
-
-  const sumResult = await client.sum(2, 3);
-  console.log("sum result:", sumResult);
-
-  const counted: Array<number> = [];
-  for await (const value of client.countTo(3)) {
-    counted.push(value);
-  }
-  console.log("count feed:", counted);
-
-  const watched: Array<number> = [];
-  for await (const value of client.watch()) {
-    watched.push(value);
-  }
-  console.log("watch feed:", watched);
-
-  client.log("fire-and-forget from demo");
+interface LocalUsersContract {
+  getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+  notifyLogin(input: { id: number; at: string }): Promise<void>;
+  liveUsers(input: { room: string }): AsyncIterable<{ id: number; at: string }>;
 }
 
-void main();
+function main() {
+  const strictService = createScompService<LocalUsersContract>('users').implement({
+    requests: {
+      getUser: async ({ id }) => ({ id, name: `user-${id}` })
+    },
+    signals: {
+      notifyLogin: async ({ id, at }) => {
+        console.log('notifyLogin', { id, at });
+      }
+    },
+    feeds: {
+      liveUsers: {
+        strategy: 'fanout',
+        handler: async function* ({ room }) {
+          yield { id: room.length, at: new Date().toISOString() };
+        }
+      }
+    }
+  });
+
+  const requestsFragment = createScompFragment<LocalUsersContract>('users').implement({
+    requests: {
+      getUser: async ({ id }) => ({ id, name: `user-${id}` })
+    }
+  });
+
+  const signalsFragment = createScompFragment<LocalUsersContract>('users').implement({
+    signals: {
+      notifyLogin: async ({ id, at }) => {
+        console.log('notifyLogin(fragment)', { id, at });
+      }
+    }
+  });
+
+  const feedsFragment = createScompFragment<LocalUsersContract>('users').implement({
+    feeds: {
+      liveUsers: async function* ({ room }) {
+        yield { id: room.length, at: new Date().toISOString() };
+      }
+    }
+  });
+
+  const composedFragment = composeScompFragments(requestsFragment, signalsFragment, feedsFragment);
+
+  console.log('strict grouped routes:', Object.keys(strictService.router).sort());
+  console.log('composed fragment routes:', Object.keys(composedFragment.router).sort());
+}
+
+main();

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -124,11 +124,13 @@ interface GroupedServiceMethodImplementationsInput<Contract extends object> {
   feeds?: Partial<GroupedMethodImplementations<Contract, 'feed'>>;
 }
 
-export interface GroupedFragmentMethodImplementations<Contract extends object> {
+type GroupedMethodImplementationsInput<Contract extends object> = {
   requests?: Partial<GroupedMethodImplementations<Contract, 'request'>>;
   signals?: Partial<GroupedMethodImplementations<Contract, 'signal'>>;
   feeds?: Partial<GroupedMethodImplementations<Contract, 'feed'>>;
-}
+};
+
+export interface GroupedFragmentMethodImplementations<Contract extends object> extends GroupedMethodImplementationsInput<Contract> {}
 
 type ServiceMethodImplementationsInput<Contract extends object> =
   | FlatServiceMethodImplementationsInput<Contract>
@@ -305,15 +307,7 @@ function compileFlatRouter(
     const inferredKind = inferRouteKind(implementation);
     const normalized = normalizeMethodConfig(implementation, inferredKind, false);
 
-    router[route] = {
-      route,
-      kind: normalized.kind,
-      parser: normalized.parser,
-      strategy: normalized.strategy,
-      hashKey: normalized.hashKey,
-      backpressure: normalized.backpressure,
-      handler: normalized.handler
-    };
+    router[route] = buildCompiledRoute(route, normalized);
   }
 
   return router;
@@ -330,16 +324,20 @@ function compileGroupedMethods(
     const route = `${name}.${methodName}`;
     const normalized = normalizeMethodConfig(implementation, kind, true);
 
-    router[route] = {
-      route,
-      kind: normalized.kind,
-      parser: normalized.parser,
-      strategy: normalized.strategy,
-      hashKey: normalized.hashKey,
-      backpressure: normalized.backpressure,
-      handler: normalized.handler
-    };
+    router[route] = buildCompiledRoute(route, normalized);
   }
+}
+
+function buildCompiledRoute(route: string, normalized: Omit<CompiledRoute, 'route'>): CompiledRoute {
+  return {
+    route,
+    kind: normalized.kind,
+    parser: normalized.parser,
+    strategy: normalized.strategy,
+    hashKey: normalized.hashKey,
+    backpressure: normalized.backpressure,
+    handler: normalized.handler
+  };
 }
 
 function compileGroupedRouter<Contract extends object>(
@@ -356,6 +354,15 @@ function compileGroupedRouter<Contract extends object>(
   compileGroupedMethods(name, 'feed', (groupedMethods.feeds ?? {}) as Record<string, unknown>, router);
 
   return router;
+}
+
+function compileImplementationsRouter<Contract extends object>(
+  name: string,
+  methods: ServiceMethodImplementationsInput<Contract> | FragmentMethodImplementations<Contract> | GroupedFragmentMethodImplementations<Contract>
+): CompiledRouter {
+  return isGroupedMethods(methods)
+    ? compileGroupedRouter(name, methods)
+    : compileFlatRouter(name, methods as Record<string, unknown>);
 }
 
 function isGroupedMethods(methods: unknown): methods is {
@@ -381,9 +388,7 @@ export function createScompService<Contract extends object>(name: string) {
     implement<Methods extends ServiceMethodImplementationsInput<Contract>>(
       methods: Methods & StrictServiceImplementationChecks<Contract, Methods>
     ): ServiceDefinition<Contract> {
-      const router = isGroupedMethods(methods)
-        ? compileGroupedRouter(name, methods)
-        : compileFlatRouter(name, methods as Record<string, unknown>);
+      const router = compileImplementationsRouter(name, methods);
 
       return {
         name,
@@ -399,9 +404,7 @@ export function createScompFragment<Contract extends object>(name: string) {
     implement<Methods extends FragmentMethodImplementations<Contract> | GroupedFragmentMethodImplementations<Contract>>(
       methods: Methods
     ): FragmentDefinition<Contract, Extract<ProvidedMethodKeys<Methods>, string>> {
-      const router = isGroupedMethods(methods)
-        ? compileGroupedRouter(name, methods)
-        : compileFlatRouter(name, methods as Record<string, unknown>);
+      const router = compileImplementationsRouter(name, methods);
 
       return {
         name,

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -110,10 +110,18 @@ export type ServiceMethodImplementations<Contract extends object> = {
 
 export type FragmentMethodImplementations<Contract extends object> = Partial<ServiceMethodImplementations<Contract>>;
 
+type FlatServiceMethodImplementationsInput<Contract extends object> = Partial<ServiceMethodImplementations<Contract>>;
+
 export interface GroupedServiceMethodImplementations<Contract extends object> {
   requests: GroupedMethodImplementations<Contract, 'request'>;
   signals: GroupedMethodImplementations<Contract, 'signal'>;
   feeds: GroupedMethodImplementations<Contract, 'feed'>;
+}
+
+interface GroupedServiceMethodImplementationsInput<Contract extends object> {
+  requests?: Partial<GroupedMethodImplementations<Contract, 'request'>>;
+  signals?: Partial<GroupedMethodImplementations<Contract, 'signal'>>;
+  feeds?: Partial<GroupedMethodImplementations<Contract, 'feed'>>;
 }
 
 export interface GroupedFragmentMethodImplementations<Contract extends object> {
@@ -121,6 +129,59 @@ export interface GroupedFragmentMethodImplementations<Contract extends object> {
   signals?: Partial<GroupedMethodImplementations<Contract, 'signal'>>;
   feeds?: Partial<GroupedMethodImplementations<Contract, 'feed'>>;
 }
+
+type ServiceMethodImplementationsInput<Contract extends object> =
+  | FlatServiceMethodImplementationsInput<Contract>
+  | GroupedServiceMethodImplementationsInput<Contract>;
+
+type GroupedProvidedMethodKeys<Grouped> =
+  Grouped extends {
+    requests?: infer Requests;
+    signals?: infer Signals;
+    feeds?: infer Feeds;
+  }
+    ? keyof NonNullable<Requests> | keyof NonNullable<Signals> | keyof NonNullable<Feeds>
+    : never;
+
+type ProvidedMethodKeys<Methods> = Methods extends {
+  requests?: unknown;
+  signals?: unknown;
+  feeds?: unknown;
+}
+  ? GroupedProvidedMethodKeys<Methods>
+  : keyof Methods;
+
+type MissingServiceMethodKeys<Contract extends object, Methods> = Exclude<
+  ContractMethodKeys<Contract>,
+  ProvidedMethodKeys<Methods>
+>;
+
+type UnknownServiceMethodKeys<Contract extends object, Methods> = Exclude<
+  ProvidedMethodKeys<Methods>,
+  ContractMethodKeys<Contract>
+>;
+
+type EnsureKnownServiceMethods<Contract extends object, Methods> =
+  [UnknownServiceMethodKeys<Contract, Methods>] extends [never]
+    ? {}
+    : {
+      __scomp_unknown_methods__: {
+        [MethodName in UnknownServiceMethodKeys<Contract, Methods>]: 'Method is not in contract';
+      };
+    };
+
+type EnsureCompleteServiceImplementation<Contract extends object, Methods> =
+  [MissingServiceMethodKeys<Contract, Methods>] extends [never]
+    ? {}
+    : {
+      __scomp_missing_methods__: {
+        [MethodName in MissingServiceMethodKeys<Contract, Methods>]: 'Missing contract implementation';
+      };
+    };
+
+type StrictServiceImplementationChecks<Contract extends object, Methods> =
+  EnsureKnownServiceMethods<Contract, Methods>
+  & EnsureCompleteServiceImplementation<Contract, Methods>;
 
 export interface CompiledRoute {
   route: string;
@@ -251,7 +312,10 @@ function compileGroupedMethods(
 
 function compileGroupedRouter<Contract extends object>(
   name: string,
-  groupedMethods: GroupedServiceMethodImplementations<Contract> | GroupedFragmentMethodImplementations<Contract>
+  groupedMethods:
+    | GroupedServiceMethodImplementations<Contract>
+    | GroupedServiceMethodImplementationsInput<Contract>
+    | GroupedFragmentMethodImplementations<Contract>
 ): CompiledRouter {
   const router: CompiledRouter = {};
 
@@ -282,12 +346,12 @@ function isGroupedMethods(methods: unknown): methods is {
 
 export function createScompService<Contract extends object>(name: string) {
   return {
-    implement(
-      methods: ServiceMethodImplementations<Contract> | GroupedServiceMethodImplementations<Contract>
+    implement<Methods extends ServiceMethodImplementationsInput<Contract>>(
+      methods: Methods & StrictServiceImplementationChecks<Contract, Methods>
     ): ServiceDefinition<Contract> {
       const router = isGroupedMethods(methods)
         ? compileGroupedRouter(name, methods)
-        : compileFlatRouter(name, methods);
+        : compileFlatRouter(name, methods as Record<string, unknown>);
 
       return {
         name,

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -203,11 +203,43 @@ export interface ServiceDefinition<Contract extends object> {
   router: CompiledRouter;
 }
 
-export interface FragmentDefinition<Contract extends object> {
+export interface FragmentDefinition<Contract extends object, Methods extends string = never> {
   name: string;
   networkIntent: Partial<ContractNetworkIntent<Contract>>;
   router: CompiledRouter;
+  readonly __scomp_fragment_methods__?: Methods;
 }
+
+type FragmentMethodNames<Fragment> =
+  Fragment extends FragmentDefinition<object, infer Methods>
+    ? Methods
+    : never;
+
+type CombinedFragmentMethodNames<Fragments extends readonly unknown[]> =
+  Fragments extends readonly [infer Fragment, ...infer Rest]
+    ? FragmentMethodNames<Fragment> | CombinedFragmentMethodNames<Rest>
+    : never;
+
+type DuplicateFragmentMethodNames<
+  Fragments extends readonly unknown[],
+  Seen extends string = never,
+  Duplicates extends string = never
+> = Fragments extends readonly [infer Fragment, ...infer Rest]
+  ? DuplicateFragmentMethodNames<
+    Rest,
+    Seen | FragmentMethodNames<Fragment>,
+    Duplicates | Extract<FragmentMethodNames<Fragment>, Seen>
+  >
+  : Duplicates;
+
+type EnsureNoDuplicateFragmentMethods<Fragments extends readonly unknown[]> =
+  [DuplicateFragmentMethodNames<Fragments>] extends [never]
+    ? {}
+    : {
+      __scomp_duplicate_fragment_methods__: {
+        [MethodName in DuplicateFragmentMethodNames<Fragments>]: 'Duplicate method declared across fragments';
+      };
+    };
 
 function normalizeMethodConfig(
   methodConfig: unknown,
@@ -364,9 +396,9 @@ export function createScompService<Contract extends object>(name: string) {
 
 export function createScompFragment<Contract extends object>(name: string) {
   return {
-    implement(
-      methods: FragmentMethodImplementations<Contract> | GroupedFragmentMethodImplementations<Contract>
-    ): FragmentDefinition<Contract> {
+    implement<Methods extends FragmentMethodImplementations<Contract> | GroupedFragmentMethodImplementations<Contract>>(
+      methods: Methods
+    ): FragmentDefinition<Contract, Extract<ProvidedMethodKeys<Methods>, string>> {
       const router = isGroupedMethods(methods)
         ? compileGroupedRouter(name, methods)
         : compileFlatRouter(name, methods as Record<string, unknown>);
@@ -377,5 +409,58 @@ export function createScompFragment<Contract extends object>(name: string) {
         router
       };
     }
+  };
+}
+
+export function composeScompFragments<
+  Contract extends object,
+  Fragments extends readonly [
+    FragmentDefinition<Contract, string>,
+    ...Array<FragmentDefinition<Contract, string>>
+  ]
+>(
+  ...fragments: Fragments & EnsureNoDuplicateFragmentMethods<Fragments>
+): FragmentDefinition<Contract, CombinedFragmentMethodNames<Fragments>> {
+  const [firstFragment] = fragments;
+  const name = firstFragment.name;
+  const router: CompiledRouter = {};
+  const networkIntent: Partial<ContractNetworkIntent<Contract>> = {};
+
+  const methodToSource = new Map<string, { fragmentLabel: string; route: string }>();
+
+  for (const [index, fragment] of fragments.entries()) {
+    const fragmentLabel = `${fragment.name}#${index + 1}`;
+
+    if (fragment.name !== name) {
+      throw new Error(`Cannot compose fragments with different names: expected "${name}", got "${fragment.name}"`);
+    }
+
+    Object.assign(networkIntent, fragment.networkIntent);
+
+    for (const [routeName, route] of Object.entries(fragment.router)) {
+      const separatorIndex = routeName.indexOf('.');
+      const methodName = separatorIndex === -1 ? routeName : routeName.slice(separatorIndex + 1);
+      const existingSource = methodToSource.get(methodName);
+
+      if (existingSource) {
+        throw new Error(
+          `Duplicate method "${methodName}" defined by fragments ${existingSource.fragmentLabel} (${existingSource.route}) and ${fragmentLabel} (${routeName})`
+        );
+      }
+
+      methodToSource.set(methodName, { fragmentLabel, route: routeName });
+
+      if (router[routeName]) {
+        throw new Error(`Duplicate route "${routeName}" while composing fragments`);
+      }
+
+      router[routeName] = route;
+    }
+  }
+
+  return {
+    name,
+    networkIntent,
+    router
   };
 }

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -108,10 +108,18 @@ export type ServiceMethodImplementations<Contract extends object> = {
   [MethodName in ContractMethodKeys<Contract>]: MethodImplementation<Extract<Contract[MethodName], AnyContractMethod>>;
 };
 
+export type FragmentMethodImplementations<Contract extends object> = Partial<ServiceMethodImplementations<Contract>>;
+
 export interface GroupedServiceMethodImplementations<Contract extends object> {
   requests: GroupedMethodImplementations<Contract, 'request'>;
   signals: GroupedMethodImplementations<Contract, 'signal'>;
   feeds: GroupedMethodImplementations<Contract, 'feed'>;
+}
+
+export interface GroupedFragmentMethodImplementations<Contract extends object> {
+  requests?: Partial<GroupedMethodImplementations<Contract, 'request'>>;
+  signals?: Partial<GroupedMethodImplementations<Contract, 'signal'>>;
+  feeds?: Partial<GroupedMethodImplementations<Contract, 'feed'>>;
 }
 
 export interface CompiledRoute {
@@ -131,6 +139,12 @@ export type CompiledRouter = Record<string, CompiledRoute>;
 export interface ServiceDefinition<Contract extends object> {
   name: string;
   networkIntent: ContractNetworkIntent<Contract>;
+  router: CompiledRouter;
+}
+
+export interface FragmentDefinition<Contract extends object> {
+  name: string;
+  networkIntent: Partial<ContractNetworkIntent<Contract>>;
   router: CompiledRouter;
 }
 
@@ -185,13 +199,13 @@ function inferRouteKind(methodConfig: unknown): RouteKind {
   return 'request';
 }
 
-function compileFlatRouter<Contract extends object>(
+function compileFlatRouter(
   name: string,
-  methods: ServiceMethodImplementations<Contract>
+  methods: Record<string, unknown>
 ): CompiledRouter {
   const router: CompiledRouter = {};
 
-  for (const methodName of Object.keys(methods) as Array<ContractMethodKeys<Contract> & string>) {
+  for (const methodName of Object.keys(methods)) {
     const implementation = methods[methodName];
     const route = `${name}.${methodName}`;
 
@@ -237,26 +251,33 @@ function compileGroupedMethods(
 
 function compileGroupedRouter<Contract extends object>(
   name: string,
-  groupedMethods: GroupedServiceMethodImplementations<Contract>
+  groupedMethods: GroupedServiceMethodImplementations<Contract> | GroupedFragmentMethodImplementations<Contract>
 ): CompiledRouter {
   const router: CompiledRouter = {};
 
-  compileGroupedMethods(name, 'request', groupedMethods.requests as Record<string, unknown>, router);
-  compileGroupedMethods(name, 'signal', groupedMethods.signals as Record<string, unknown>, router);
-  compileGroupedMethods(name, 'feed', groupedMethods.feeds as Record<string, unknown>, router);
+  compileGroupedMethods(name, 'request', (groupedMethods.requests ?? {}) as Record<string, unknown>, router);
+  compileGroupedMethods(name, 'signal', (groupedMethods.signals ?? {}) as Record<string, unknown>, router);
+  compileGroupedMethods(name, 'feed', (groupedMethods.feeds ?? {}) as Record<string, unknown>, router);
 
   return router;
 }
 
-function isGroupedMethods<Contract extends object>(
-  methods: ServiceMethodImplementations<Contract> | GroupedServiceMethodImplementations<Contract>
-): methods is GroupedServiceMethodImplementations<Contract> {
+function isGroupedMethods(methods: unknown): methods is {
+  requests?: Record<string, unknown>;
+  signals?: Record<string, unknown>;
+  feeds?: Record<string, unknown>;
+} {
   if (typeof methods !== 'object' || methods === null) {
     return false;
   }
 
   const methodMap = methods as Record<string, unknown>;
-  return 'requests' in methodMap && 'signals' in methodMap && 'feeds' in methodMap;
+  const methodKeys = Object.keys(methodMap);
+  if (methodKeys.length === 0) {
+    return false;
+  }
+
+  return methodKeys.every((key) => key === 'requests' || key === 'signals' || key === 'feeds');
 }
 
 export function createScompService<Contract extends object>(name: string) {
@@ -271,6 +292,24 @@ export function createScompService<Contract extends object>(name: string) {
       return {
         name,
         networkIntent: {} as ContractNetworkIntent<Contract>,
+        router
+      };
+    }
+  };
+}
+
+export function createScompFragment<Contract extends object>(name: string) {
+  return {
+    implement(
+      methods: FragmentMethodImplementations<Contract> | GroupedFragmentMethodImplementations<Contract>
+    ): FragmentDefinition<Contract> {
+      const router = isGroupedMethods(methods)
+        ? compileGroupedRouter(name, methods)
+        : compileFlatRouter(name, methods as Record<string, unknown>);
+
+      return {
+        name,
+        networkIntent: {} as Partial<ContractNetworkIntent<Contract>>,
         router
       };
     }

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -1,5 +1,7 @@
 import type { AnyContractMethod, ContractNetworkIntent, ContractMethodInput } from '@scomp/types';
 
+type RouteKind = 'request' | 'signal' | 'feed';
+
 export interface RequestImplementationConfig<Input, Output> {
   kind?: 'request';
   parser?: (payload: unknown) => Input;
@@ -39,22 +41,82 @@ type FeedRawHandler<Method> = Method extends (input: infer Input) => AsyncIterab
   ? (input: Input) => AsyncIterable<Output>
   : never;
 
-type MethodImplementation<Method extends AnyContractMethod> =
-  ReturnType<Method> extends AsyncIterable<infer FeedOutput>
-    ? FeedRawHandler<Method> | FeedImplementationConfig<ContractMethodInput<Method>, FeedOutput>
+type MethodKind<Method extends AnyContractMethod> =
+  ReturnType<Method> extends AsyncIterable<unknown>
+    ? 'feed'
     : ReturnType<Method> extends void | Promise<void>
-      ? SignalRawHandler<Method> | SignalImplementationConfig<ContractMethodInput<Method>>
-      : ReturnType<Method> extends Promise<infer RequestOutput>
-        ? RequestRawHandler<Method> | RequestImplementationConfig<ContractMethodInput<Method>, RequestOutput>
+      ? 'signal'
+      : ReturnType<Method> extends Promise<unknown>
+        ? 'request'
         : never;
+
+type RequestMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends 'request'
+    ? RequestRawHandler<Method> | RequestImplementationConfig<ContractMethodInput<Method>, Awaited<ReturnType<Method>>>
+    : never;
+
+type SignalMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends 'signal'
+    ? SignalRawHandler<Method> | SignalImplementationConfig<ContractMethodInput<Method>>
+    : never;
+
+type FeedMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends 'feed'
+    ? FeedRawHandler<Method> | FeedImplementationConfig<ContractMethodInput<Method>, ReturnType<Method> extends AsyncIterable<infer Output> ? Output : never>
+    : never;
+
+type GroupedRequestImplementationConfig<Input, Output> = Omit<RequestImplementationConfig<Input, Output>, 'kind'>;
+type GroupedSignalImplementationConfig<Input> = Omit<SignalImplementationConfig<Input>, 'kind'>;
+type GroupedFeedImplementationConfig<Input, Output> = Omit<FeedImplementationConfig<Input, Output>, 'kind'>;
+
+type GroupedRequestMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends 'request'
+    ? RequestRawHandler<Method> | GroupedRequestImplementationConfig<ContractMethodInput<Method>, Awaited<ReturnType<Method>>>
+    : never;
+
+type GroupedSignalMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends 'signal'
+    ? SignalRawHandler<Method> | GroupedSignalImplementationConfig<ContractMethodInput<Method>>
+    : never;
+
+type GroupedFeedMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends 'feed'
+    ? FeedRawHandler<Method> | GroupedFeedImplementationConfig<ContractMethodInput<Method>, ReturnType<Method> extends AsyncIterable<infer Output> ? Output : never>
+    : never;
+
+type ContractMethodKeysByKind<Contract extends object, Kind extends RouteKind> = {
+  [MethodName in ContractMethodKeys<Contract>]: MethodKind<Extract<Contract[MethodName], AnyContractMethod>> extends Kind
+    ? MethodName
+    : never;
+}[ContractMethodKeys<Contract>];
+
+type GroupedMethodImplementations<Contract extends object, Kind extends RouteKind> = {
+  [MethodName in ContractMethodKeysByKind<Contract, Kind>]:
+  Kind extends 'request'
+    ? GroupedRequestMethodImplementation<Extract<Contract[MethodName], AnyContractMethod>>
+    : Kind extends 'signal'
+      ? GroupedSignalMethodImplementation<Extract<Contract[MethodName], AnyContractMethod>>
+      : GroupedFeedMethodImplementation<Extract<Contract[MethodName], AnyContractMethod>>;
+};
+
+type MethodImplementation<Method extends AnyContractMethod> =
+  RequestMethodImplementation<Method>
+  | SignalMethodImplementation<Method>
+  | FeedMethodImplementation<Method>;
 
 export type ServiceMethodImplementations<Contract extends object> = {
   [MethodName in ContractMethodKeys<Contract>]: MethodImplementation<Extract<Contract[MethodName], AnyContractMethod>>;
 };
 
+export interface GroupedServiceMethodImplementations<Contract extends object> {
+  requests: GroupedMethodImplementations<Contract, 'request'>;
+  signals: GroupedMethodImplementations<Contract, 'signal'>;
+  feeds: GroupedMethodImplementations<Contract, 'feed'>;
+}
+
 export interface CompiledRoute {
   route: string;
-  kind: 'request' | 'signal' | 'feed';
+  kind: RouteKind;
   parser?: (payload: unknown) => unknown;
   strategy?: 'fanout' | 'exclusive';
   hashKey?: (payload: unknown) => string;
@@ -72,7 +134,11 @@ export interface ServiceDefinition<Contract extends object> {
   router: CompiledRouter;
 }
 
-function normalizeMethodConfig(methodConfig: unknown, inferredKind: 'request' | 'signal' | 'feed'): Omit<CompiledRoute, 'route'> {
+function normalizeMethodConfig(
+  methodConfig: unknown,
+  inferredKind: RouteKind,
+  deterministicKind: boolean
+): Omit<CompiledRoute, 'route'> {
   if (typeof methodConfig === 'function') {
     if (inferredKind === 'feed') {
       return {
@@ -89,7 +155,9 @@ function normalizeMethodConfig(methodConfig: unknown, inferredKind: 'request' | 
   }
 
   const configObject = methodConfig as Record<string, unknown>;
-  const kind = (configObject.kind as 'request' | 'signal' | 'feed' | undefined) ?? inferredKind;
+  const kind = deterministicKind
+    ? inferredKind
+    : (configObject.kind as RouteKind | undefined) ?? inferredKind;
   return {
     kind,
     parser: configObject.parser as ((payload: unknown) => unknown) | undefined,
@@ -100,7 +168,7 @@ function normalizeMethodConfig(methodConfig: unknown, inferredKind: 'request' | 
   };
 }
 
-function inferRouteKind(methodConfig: unknown): 'request' | 'signal' | 'feed' {
+function inferRouteKind(methodConfig: unknown): RouteKind {
   if (typeof methodConfig === 'function') {
     return 'request';
   }
@@ -117,7 +185,7 @@ function inferRouteKind(methodConfig: unknown): 'request' | 'signal' | 'feed' {
   return 'request';
 }
 
-function compileRouter<Contract extends object>(
+function compileFlatRouter<Contract extends object>(
   name: string,
   methods: ServiceMethodImplementations<Contract>
 ): CompiledRouter {
@@ -128,7 +196,7 @@ function compileRouter<Contract extends object>(
     const route = `${name}.${methodName}`;
 
     const inferredKind = inferRouteKind(implementation);
-    const normalized = normalizeMethodConfig(implementation, inferredKind);
+    const normalized = normalizeMethodConfig(implementation, inferredKind, false);
 
     router[route] = {
       route,
@@ -144,10 +212,61 @@ function compileRouter<Contract extends object>(
   return router;
 }
 
+function compileGroupedMethods(
+  name: string,
+  kind: RouteKind,
+  methods: Record<string, unknown>,
+  router: CompiledRouter
+) {
+  for (const methodName of Object.keys(methods)) {
+    const implementation = methods[methodName];
+    const route = `${name}.${methodName}`;
+    const normalized = normalizeMethodConfig(implementation, kind, true);
+
+    router[route] = {
+      route,
+      kind: normalized.kind,
+      parser: normalized.parser,
+      strategy: normalized.strategy,
+      hashKey: normalized.hashKey,
+      backpressure: normalized.backpressure,
+      handler: normalized.handler
+    };
+  }
+}
+
+function compileGroupedRouter<Contract extends object>(
+  name: string,
+  groupedMethods: GroupedServiceMethodImplementations<Contract>
+): CompiledRouter {
+  const router: CompiledRouter = {};
+
+  compileGroupedMethods(name, 'request', groupedMethods.requests as Record<string, unknown>, router);
+  compileGroupedMethods(name, 'signal', groupedMethods.signals as Record<string, unknown>, router);
+  compileGroupedMethods(name, 'feed', groupedMethods.feeds as Record<string, unknown>, router);
+
+  return router;
+}
+
+function isGroupedMethods<Contract extends object>(
+  methods: ServiceMethodImplementations<Contract> | GroupedServiceMethodImplementations<Contract>
+): methods is GroupedServiceMethodImplementations<Contract> {
+  if (typeof methods !== 'object' || methods === null) {
+    return false;
+  }
+
+  const methodMap = methods as Record<string, unknown>;
+  return 'requests' in methodMap && 'signals' in methodMap && 'feeds' in methodMap;
+}
+
 export function createScompService<Contract extends object>(name: string) {
   return {
-    implement(methods: ServiceMethodImplementations<Contract>): ServiceDefinition<Contract> {
-      const router = compileRouter(name, methods);
+    implement(
+      methods: ServiceMethodImplementations<Contract> | GroupedServiceMethodImplementations<Contract>
+    ): ServiceDefinition<Contract> {
+      const router = isGroupedMethods(methods)
+        ? compileGroupedRouter(name, methods)
+        : compileFlatRouter(name, methods);
 
       return {
         name,

--- a/packages/core/src/builder.type-test.ts
+++ b/packages/core/src/builder.type-test.ts
@@ -22,6 +22,16 @@ createScompService<GroupedTypesContract>('users').implement({
   }
 });
 
+createScompService<GroupedTypesContract>('users').implement({
+  getUser: async ({ id }) => ({ id }),
+  notifyLogin: async () => {
+    return;
+  },
+  liveUsers: async function* () {
+    yield { id: 1 };
+  }
+});
+
 createScompFragment<GroupedTypesContract>('users').implement({
   requests: {
     getUser: async ({ id }) => ({ id })
@@ -86,6 +96,26 @@ createScompService<GroupedTypesContract>('users').implement({
   feeds: {
     liveUsers: async function* () {
       yield { id: 1 };
+    }
+  }
+});
+
+// @ts-expect-error - strict services must implement all contract methods (missing liveUsers)
+createScompService<GroupedTypesContract>('users').implement({
+  getUser: async ({ id }) => ({ id }),
+  notifyLogin: async () => {
+    return;
+  }
+});
+
+// @ts-expect-error - strict grouped services must implement all contract methods (missing liveUsers feed)
+createScompService<GroupedTypesContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id })
+  },
+  signals: {
+    notifyLogin: async () => {
+      return;
     }
   }
 });

--- a/packages/core/src/builder.type-test.ts
+++ b/packages/core/src/builder.type-test.ts
@@ -22,6 +22,25 @@ createScompService<GroupedTypesContract>('users').implement({
   }
 });
 
+createScompService<GroupedTypesContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id })
+  },
+  signals: {
+    notifyLogin: async () => {
+      return;
+    }
+  },
+  feeds: {
+    liveUsers: {
+      strategy: 'fanout',
+      handler: async function* ({ room }) {
+        yield { id: room.length };
+      }
+    }
+  }
+});
+
 const userRequests = createScompFragment<GroupedTypesContract>('users').implement({
   requests: {
     getUser: async ({ id }) => ({ id })
@@ -38,6 +57,16 @@ const userSignals = createScompFragment<GroupedTypesContract>('users').implement
 
 composeScompFragments(userRequests, userSignals);
 
+const userFeeds = createScompFragment<GroupedTypesContract>('users').implement({
+  feeds: {
+    liveUsers: async function* ({ room }) {
+      yield { id: room.length };
+    }
+  }
+});
+
+composeScompFragments(userRequests, userSignals, userFeeds);
+
 const duplicateUserRequests = createScompFragment<GroupedTypesContract>('users').implement({
   requests: {
     getUser: async ({ id }) => ({ id })
@@ -47,6 +76,17 @@ const duplicateUserRequests = createScompFragment<GroupedTypesContract>('users')
 // @ts-expect-error - duplicate methods across fragments are rejected
 composeScompFragments(userRequests, duplicateUserRequests);
 
+const duplicateUserSignals = createScompFragment<GroupedTypesContract>('users').implement({
+  signals: {
+    notifyLogin: async () => {
+      return;
+    }
+  }
+});
+
+// @ts-expect-error - duplicate methods are rejected even when only one fragment duplicates
+composeScompFragments(userRequests, userSignals, duplicateUserSignals);
+
 createScompService<GroupedTypesContract>('users').implement({
   getUser: async ({ id }) => ({ id }),
   notifyLogin: async () => {
@@ -55,6 +95,18 @@ createScompService<GroupedTypesContract>('users').implement({
   liveUsers: async function* () {
     yield { id: 1 };
   }
+});
+
+// @ts-expect-error - strict services reject unknown flat methods
+createScompService<GroupedTypesContract>('users').implement({
+  getUser: async ({ id }) => ({ id }),
+  notifyLogin: async () => {
+    return;
+  },
+  liveUsers: async function* () {
+    yield { id: 1 };
+  },
+  unknownMethod: async () => 'nope'
 });
 
 createScompFragment<GroupedTypesContract>('users').implement({
@@ -110,6 +162,24 @@ createScompService<GroupedTypesContract>('users').implement({
   }
 });
 
+// @ts-expect-error - strict grouped services reject unknown grouped methods
+createScompService<GroupedTypesContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id }),
+    unknownMethod: async () => ({ id: 0 })
+  },
+  signals: {
+    notifyLogin: async () => {
+      return;
+    }
+  },
+  feeds: {
+    liveUsers: async function* () {
+      yield { id: 1 };
+    }
+  }
+});
+
 createScompService<GroupedTypesContract>('users').implement({
   requests: {
     getUser: async ({ id }) => ({ id })
@@ -141,6 +211,18 @@ createScompService<GroupedTypesContract>('users').implement({
   signals: {
     notifyLogin: async () => {
       return;
+    }
+  }
+});
+
+// @ts-expect-error - strict grouped services must implement all contract methods (missing notifyLogin signal)
+createScompService<GroupedTypesContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id })
+  },
+  feeds: {
+    liveUsers: async function* () {
+      yield { id: 1 };
     }
   }
 });

--- a/packages/core/src/builder.type-test.ts
+++ b/packages/core/src/builder.type-test.ts
@@ -1,0 +1,57 @@
+import { createScompService } from './builder';
+
+interface GroupedTypesContract {
+  getUser(input: { id: number }): Promise<{ id: number }>;
+  notifyLogin(input: { id: number }): Promise<void>;
+  liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
+}
+
+createScompService<GroupedTypesContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id })
+  },
+  signals: {
+    notifyLogin: async () => {
+      return;
+    }
+  },
+  feeds: {
+    liveUsers: async function* ({ room }) {
+      yield { id: room.length };
+    }
+  }
+});
+
+createScompService<GroupedTypesContract>('users').implement({
+  requests: {
+    // @ts-expect-error - notifyLogin is a signal and cannot be in requests
+    notifyLogin: async () => {
+      return;
+    }
+  },
+  signals: {
+    notifyLogin: async () => {
+      return;
+    }
+  },
+  feeds: {
+    liveUsers: async function* () {
+      yield { id: 1 };
+    }
+  }
+});
+
+createScompService<GroupedTypesContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id })
+  },
+  signals: {
+    // @ts-expect-error - signal handlers must return void | Promise<void>
+    notifyLogin: async ({ id }) => ({ id })
+  },
+  feeds: {
+    liveUsers: async function* () {
+      yield { id: 1 };
+    }
+  }
+});

--- a/packages/core/src/builder.type-test.ts
+++ b/packages/core/src/builder.type-test.ts
@@ -1,4 +1,4 @@
-import { createScompService } from './builder';
+import { createScompFragment, createScompService } from './builder';
 
 interface GroupedTypesContract {
   getUser(input: { id: number }): Promise<{ id: number }>;
@@ -19,6 +19,40 @@ createScompService<GroupedTypesContract>('users').implement({
     liveUsers: async function* ({ room }) {
       yield { id: room.length };
     }
+  }
+});
+
+createScompFragment<GroupedTypesContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id })
+  }
+});
+
+createScompFragment<GroupedTypesContract>('users').implement({
+  signals: {
+    notifyLogin: async () => {
+      return;
+    }
+  }
+});
+
+createScompFragment<GroupedTypesContract>('users').implement({
+  getUser: async ({ id }) => ({ id })
+});
+
+createScompFragment<GroupedTypesContract>('users').implement({
+  requests: {
+    // @ts-expect-error - notifyLogin is a signal and cannot be in requests
+    notifyLogin: async () => {
+      return;
+    }
+  }
+});
+
+createScompFragment<GroupedTypesContract>('users').implement({
+  signals: {
+    // @ts-expect-error - signal handlers must return void | Promise<void>
+    notifyLogin: async ({ id }) => ({ id })
   }
 });
 

--- a/packages/core/src/builder.type-test.ts
+++ b/packages/core/src/builder.type-test.ts
@@ -1,4 +1,4 @@
-import { createScompFragment, createScompService } from './builder';
+import { composeScompFragments, createScompFragment, createScompService } from './builder';
 
 interface GroupedTypesContract {
   getUser(input: { id: number }): Promise<{ id: number }>;
@@ -21,6 +21,31 @@ createScompService<GroupedTypesContract>('users').implement({
     }
   }
 });
+
+const userRequests = createScompFragment<GroupedTypesContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id })
+  }
+});
+
+const userSignals = createScompFragment<GroupedTypesContract>('users').implement({
+  signals: {
+    notifyLogin: async () => {
+      return;
+    }
+  }
+});
+
+composeScompFragments(userRequests, userSignals);
+
+const duplicateUserRequests = createScompFragment<GroupedTypesContract>('users').implement({
+  requests: {
+    getUser: async ({ id }) => ({ id })
+  }
+});
+
+// @ts-expect-error - duplicate methods across fragments are rejected
+composeScompFragments(userRequests, duplicateUserRequests);
 
 createScompService<GroupedTypesContract>('users').implement({
   getUser: async ({ id }) => ({ id }),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export {
 } from "./feed";
 
 export {
+  composeScompFragments,
   createScompFragment,
   createScompService,
   type CompiledRoute,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export {
   type CompiledRoute,
   type CompiledRouter,
   type FeedImplementationConfig,
+  type GroupedServiceMethodImplementations,
   type RequestImplementationConfig,
   type ServiceDefinition,
   type SignalImplementationConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,10 +9,14 @@ export {
 } from "./feed";
 
 export {
+  createScompFragment,
   createScompService,
   type CompiledRoute,
   type CompiledRouter,
+  type FragmentDefinition,
+  type FragmentMethodImplementations,
   type FeedImplementationConfig,
+  type GroupedFragmentMethodImplementations,
   type GroupedServiceMethodImplementations,
   type RequestImplementationConfig,
   type ServiceDefinition,

--- a/packages/core/test/scomp-builder.spec.ts
+++ b/packages/core/test/scomp-builder.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { createScompService } from '../src';
+import { createScompFragment, createScompService } from '../src';
 
 describe('createScompService contract builder', () => {
   it('supports grouped requests/signals/feeds authoring with deterministic route kinds', async () => {
@@ -131,5 +131,58 @@ describe('createScompService contract builder', () => {
     assert.equal(route.kind, 'request');
     const result = await (route.handler({ left: 2, right: 5 }) as Promise<number>);
     assert.equal(result, 7);
+  });
+});
+
+describe('createScompFragment contract builder', () => {
+  it('supports grouped partial fragment authoring with deterministic route kinds', async () => {
+    interface UsersContract {
+      getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+      notifyLogin(input: { id: number }): Promise<void>;
+      liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
+    }
+
+    const fragment = createScompFragment<UsersContract>('users').implement({
+      requests: {
+        getUser: async ({ id }) => ({ id, name: `u-${id}` })
+      },
+      feeds: {
+        liveUsers: {
+          strategy: 'exclusive',
+          handler: async function* () {
+            yield { id: 1 };
+          }
+        }
+      }
+    });
+
+    assert.equal(fragment.name, 'users');
+    assert.equal(fragment.router['users.getUser'].kind, 'request');
+    assert.equal(fragment.router['users.liveUsers'].kind, 'feed');
+    assert.equal(fragment.router['users.notifyLogin'], undefined);
+
+    const getUserResult = await (fragment.router['users.getUser'].handler({ id: 7 }) as Promise<{ id: number; name: string }>);
+    assert.deepEqual(getUserResult, { id: 7, name: 'u-7' });
+  });
+
+  it('supports flat partial fragment authoring', async () => {
+    interface UsersContract {
+      getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+      notifyLogin(input: { id: number }): Promise<void>;
+      liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
+    }
+
+    const fragment = createScompFragment<UsersContract>('users').implement({
+      notifyLogin: {
+        kind: 'signal',
+        handler: async () => {
+          return;
+        }
+      }
+    });
+
+    assert.equal(fragment.router['users.notifyLogin'].kind, 'signal');
+    await fragment.router['users.notifyLogin'].handler({ id: 99 });
+    assert.equal(fragment.router['users.getUser'], undefined);
   });
 });

--- a/packages/core/test/scomp-builder.spec.ts
+++ b/packages/core/test/scomp-builder.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { createScompFragment, createScompService } from '../src';
+import { composeScompFragments, createScompFragment, createScompService } from '../src';
 
 describe('createScompService contract builder', () => {
   it('supports grouped requests/signals/feeds authoring with deterministic route kinds', async () => {
@@ -184,5 +184,55 @@ describe('createScompFragment contract builder', () => {
     assert.equal(fragment.router['users.notifyLogin'].kind, 'signal');
     await fragment.router['users.notifyLogin'].handler({ id: 99 });
     assert.equal(fragment.router['users.getUser'], undefined);
+  });
+
+  it('composes fragments without overriding methods', async () => {
+    interface UsersContract {
+      getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+      notifyLogin(input: { id: number }): Promise<void>;
+      liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
+    }
+
+    const requestsFragment = createScompFragment<UsersContract>('users').implement({
+      requests: {
+        getUser: async ({ id }) => ({ id, name: `u-${id}` })
+      }
+    });
+
+    const signalsFragment = createScompFragment<UsersContract>('users').implement({
+      signals: {
+        notifyLogin: async () => {
+          return;
+        }
+      }
+    });
+
+    const composed = composeScompFragments(requestsFragment, signalsFragment);
+
+    assert.equal(composed.router['users.getUser'].kind, 'request');
+    assert.equal(composed.router['users.notifyLogin'].kind, 'signal');
+  });
+
+  it('rejects duplicate methods when composing fragments', () => {
+    interface UsersContract {
+      getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+    }
+
+    const first = createScompFragment<UsersContract>('users').implement({
+      requests: {
+        getUser: async ({ id }) => ({ id, name: `a-${id}` })
+      }
+    });
+
+    const second = createScompFragment<UsersContract>('users').implement({
+      requests: {
+        getUser: async ({ id }) => ({ id, name: `b-${id}` })
+      }
+    });
+
+    assert.throws(
+      () => composeScompFragments(first, second),
+      /Duplicate method "getUser" defined by fragments users#1 \(users.getUser\) and users#2 \(users.getUser\)/
+    );
   });
 });

--- a/packages/core/test/scomp-builder.spec.ts
+++ b/packages/core/test/scomp-builder.spec.ts
@@ -1,5 +1,11 @@
 import assert from 'node:assert/strict';
-import { composeScompFragments, createScompFragment, createScompService } from '../src';
+import {
+  composeScompFragments,
+  createNodeLocalDiscoverHandler,
+  createNodeLocalResolveHandler,
+  createScompFragment,
+  createScompService
+} from '../src';
 
 describe('createScompService contract builder', () => {
   it('supports grouped requests/signals/feeds authoring with deterministic route kinds', async () => {
@@ -59,6 +65,44 @@ describe('createScompService contract builder', () => {
     const liveIterator = (liveRoute.handler({ room: 'general' }) as AsyncIterable<{ id: number }>)[Symbol.asyncIterator]();
     const firstChunk = await liveIterator.next();
     assert.deepEqual(firstChunk, { value: { id: 1 }, done: false });
+  });
+
+  it('keeps grouped route kind deterministic even if method configs include conflicting kinds', () => {
+    interface UsersContract {
+      getUser(input: { id: number }): Promise<{ id: number }>;
+      notifyLogin(input: { id: number }): Promise<void>;
+      liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
+    }
+
+    const service = createScompService<UsersContract>('users').implement({
+      requests: {
+        getUser: {
+          kind: 'feed',
+          handler: async (input: { id: number }) => ({ id: input.id })
+        } as unknown as (input: { id: number }) => Promise<{ id: number }>
+      },
+      signals: {
+        notifyLogin: {
+          kind: 'request',
+          handler: async () => {
+            return;
+          }
+        } as unknown as (input: { id: number }) => Promise<void>
+      },
+      feeds: {
+        liveUsers: {
+          kind: 'signal',
+          strategy: 'exclusive',
+          handler: async function* () {
+            yield { id: 1 };
+          }
+        } as unknown as (input: { room: string }) => AsyncIterable<{ id: number }>
+      }
+    });
+
+    assert.equal(service.router['users.getUser'].kind, 'request');
+    assert.equal(service.router['users.notifyLogin'].kind, 'signal');
+    assert.equal(service.router['users.liveUsers'].kind, 'feed');
   });
 
   it('compiles request, signal, and feed methods into a flat routing table', async () => {
@@ -213,6 +257,76 @@ describe('createScompFragment contract builder', () => {
     assert.equal(composed.router['users.notifyLogin'].kind, 'signal');
   });
 
+  it('composed fragment router remains compatible with discover/resolve control-plane handlers', () => {
+    interface UsersContract {
+      getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+      notifyLogin(input: { id: number }): Promise<void>;
+      liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
+    }
+
+    const requestsFragment = createScompFragment<UsersContract>('users').implement({
+      requests: {
+        getUser: async ({ id }) => ({ id, name: `u-${id}` })
+      }
+    });
+
+    const signalsFragment = createScompFragment<UsersContract>('users').implement({
+      signals: {
+        notifyLogin: async () => {
+          return;
+        }
+      }
+    });
+
+    const feedsFragment = createScompFragment<UsersContract>('users').implement({
+      feeds: {
+        liveUsers: {
+          strategy: 'fanout',
+          handler: async function* () {
+            yield { id: 1 };
+          }
+        }
+      }
+    });
+
+    const composed = composeScompFragments(requestsFragment, signalsFragment, feedsFragment);
+    const discover = createNodeLocalDiscoverHandler(composed.router, {
+      nodeId: 'node-1'
+    });
+    const resolve = createNodeLocalResolveHandler(composed.router, {
+      defaultTransport: 'inproc'
+    });
+
+    const discovered = discover({ includeRoutes: true });
+    assert.deepEqual(discovered.services, [
+      {
+        name: 'users',
+        routes: ['users.getUser', 'users.liveUsers', 'users.notifyLogin']
+      }
+    ]);
+
+    const resolved = resolve({ route: 'users.notifyLogin', channel: 'alpha' });
+    assert.equal(resolved.resolved, true);
+    assert.equal(resolved.fallbackUsed, true);
+    assert.deepEqual(resolved.endpoint, {
+      route: 'users.notifyLogin',
+      channel: 'current-channel',
+      transport: 'inproc'
+    });
+    assert.deepEqual(resolved.candidates, [
+      {
+        route: 'users.notifyLogin',
+        channel: 'alpha',
+        transport: 'inproc'
+      },
+      {
+        route: 'users.notifyLogin',
+        channel: 'current-channel',
+        transport: 'inproc'
+      }
+    ]);
+  });
+
   it('rejects duplicate methods when composing fragments', () => {
     interface UsersContract {
       getUser(input: { id: number }): Promise<{ id: number; name: string }>;
@@ -231,7 +345,7 @@ describe('createScompFragment contract builder', () => {
     });
 
     assert.throws(
-      () => composeScompFragments(first, second),
+      () => composeScompFragments(first as never, second as never),
       /Duplicate method "getUser" defined by fragments users#1 \(users.getUser\) and users#2 \(users.getUser\)/
     );
   });

--- a/packages/core/test/scomp-builder.spec.ts
+++ b/packages/core/test/scomp-builder.spec.ts
@@ -2,6 +2,65 @@ import assert from 'node:assert/strict';
 import { createScompService } from '../src';
 
 describe('createScompService contract builder', () => {
+  it('supports grouped requests/signals/feeds authoring with deterministic route kinds', async () => {
+    interface UsersContract {
+      getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+      notifyLogin(input: { id: number }): Promise<void>;
+      liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
+    }
+
+    const service = createScompService<UsersContract>('users').implement({
+      requests: {
+        getUser: {
+          parser: (payload): { id: number } => {
+            const value = payload as { id: number };
+            return { id: Number(value.id) };
+          },
+          handler: async (input) => ({ id: input.id, name: `u-${input.id}` })
+        }
+      },
+      signals: {
+        notifyLogin: {
+          parser: (payload): { id: number } => {
+            const value = payload as { id: number };
+            return { id: Number(value.id) };
+          },
+          handler: async () => {
+            return;
+          }
+        }
+      },
+      feeds: {
+        liveUsers: {
+          strategy: 'fanout',
+          hashKey: (input) => input.room,
+          backpressure: { highWaterMark: 8 },
+          handler: async function* () {
+            yield { id: 1 };
+          }
+        }
+      }
+    });
+
+    const getUserRoute = service.router['users.getUser'];
+    const signalRoute = service.router['users.notifyLogin'];
+    const liveRoute = service.router['users.liveUsers'];
+
+    assert.equal(getUserRoute.kind, 'request');
+    assert.equal(signalRoute.kind, 'signal');
+    assert.equal(liveRoute.kind, 'feed');
+    assert.equal(liveRoute.strategy, 'fanout');
+    assert.equal(liveRoute.backpressure?.highWaterMark, 8);
+    assert.equal(typeof liveRoute.hashKey, 'function');
+
+    const getUserResult = await (getUserRoute.handler(getUserRoute.parser?.({ id: '9' }) ?? { id: 0 }) as Promise<{ id: number; name: string }>);
+    assert.deepEqual(getUserResult, { id: 9, name: 'u-9' });
+
+    const liveIterator = (liveRoute.handler({ room: 'general' }) as AsyncIterable<{ id: number }>)[Symbol.asyncIterator]();
+    const firstChunk = await liveIterator.next();
+    assert.deepEqual(firstChunk, { value: { id: 1 }, done: false });
+  });
+
   it('compiles request, signal, and feed methods into a flat routing table', async () => {
     interface UsersContract {
       getUser(input: { id: number }): Promise<{ id: number; name: string }>;

--- a/packages/transport-rabbitmq/test/rabbitmq-transport.spec.ts
+++ b/packages/transport-rabbitmq/test/rabbitmq-transport.spec.ts
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
 import {
+  composeScompFragments,
+  createScompFragment,
+  createScompService,
+} from "@scomp/core";
+import {
   createJsonSerializer,
   RabbitMQTransport,
   StreamClosedError,
@@ -163,6 +168,159 @@ describe("RabbitMQTransport NFR behavior", () => {
       running.abortController.signal.reason instanceof StreamClosedError,
       true,
     );
+  });
+
+  it("keeps grouped and composed fragment routers transport-compatible", async () => {
+    interface UsersContract {
+      getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+      notifyLogin(input: { id: number }): Promise<void>;
+      liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
+    }
+
+    const groupedSignals: Array<unknown> = [];
+    const grouped = createScompService<UsersContract>("users").implement({
+      requests: {
+        getUser: async ({ id }: { id: number }) => ({ id, name: `u-${id}` }),
+      },
+      signals: {
+        notifyLogin: async (payload: { id: number }) => {
+          groupedSignals.push(payload);
+        },
+      },
+      feeds: {
+        liveUsers: {
+          strategy: "fanout",
+          hashKey: ({ room }: { room: string }) => room,
+          handler: async function* () {
+            yield { id: 1 };
+          },
+        },
+      },
+    });
+
+    const composedSignals: Array<unknown> = [];
+    const requestFragment = createScompFragment<UsersContract>("users").implement(
+      {
+        requests: {
+          getUser: async ({ id }: { id: number }) => ({ id, name: `u-${id}` }),
+        },
+      },
+    );
+    const signalFragment = createScompFragment<UsersContract>("users").implement(
+      {
+        signals: {
+          notifyLogin: async (payload: { id: number }) => {
+            composedSignals.push(payload);
+          },
+        },
+      },
+    );
+    const feedFragment = createScompFragment<UsersContract>("users").implement({
+      feeds: {
+        liveUsers: {
+          strategy: "fanout",
+          hashKey: ({ room }: { room: string }) => room,
+          handler: async function* () {
+            yield { id: 1 };
+          },
+        },
+      },
+    });
+    const composed = composeScompFragments(
+      requestFragment,
+      signalFragment,
+      feedFragment,
+    );
+
+    const cases = [
+      { router: grouped.router, seenSignals: groupedSignals },
+      { router: composed.router, seenSignals: composedSignals },
+    ];
+
+    for (const { router, seenSignals } of cases) {
+      const fake = createFakeChannel();
+      mockConnect.mockResolvedValue(fake.connection);
+
+      const transport = new RabbitMQTransport({ url: "amqp://test" });
+      await transport.listen(router as unknown as Record<string, unknown>);
+
+      // Intentional parity assertion: grouped/composed outputs still classify
+      // request/signal/feed exactly as legacy transport dispatch expects.
+      assert.equal(router["users.getUser"].kind, "request");
+      assert.equal(router["users.notifyLogin"].kind, "signal");
+      assert.equal(router["users.liveUsers"].kind, "feed");
+
+      const rpcConsumer = fake.queueConsumers.get("scomp.rpc.users");
+      assert.ok(rpcConsumer);
+
+      await rpcConsumer?.(
+        createMessage(
+          {
+            route: "users.getUser",
+            op: "request",
+            payload: { id: 7 },
+          },
+          {
+            properties: {
+              correlationId: "corr-request",
+              replyTo: "reply-users",
+            },
+          },
+        ),
+      );
+
+      const requestReply = fake.channel.sendToQueue.mock.calls.find(
+        ([queue]) => queue === "reply-users",
+      );
+      assert.ok(requestReply);
+      const requestBody = JSON.parse(
+        Buffer.from(requestReply[1]).toString("utf8"),
+      ) as { payload?: unknown };
+      assert.deepEqual(requestBody.payload, { id: 7, name: "u-7" });
+
+      const signalQueue = Array.from(fake.queueConsumers.keys()).find((queue) =>
+        queue.startsWith("scomp.event.users."),
+      );
+      assert.ok(signalQueue);
+      await fake.queueConsumers.get(String(signalQueue))?.(
+        createMessage({
+          route: "users.notifyLogin",
+          op: "signal",
+          payload: { id: 7 },
+        }),
+      );
+      assert.deepEqual(seenSignals, [{ id: 7 }]);
+
+      await rpcConsumer?.(
+        createMessage(
+          {
+            route: "users.liveUsers",
+            op: "feed_start",
+            payload: { room: "general" },
+          },
+          {
+            properties: {
+              correlationId: "corr-feed-start",
+              replyTo: "reply-users",
+            },
+          },
+        ),
+      );
+
+      const feedStartReply = fake.channel.sendToQueue.mock.calls.find(
+        ([queue, body]) =>
+          queue === "reply-users" &&
+          String(Buffer.from(body).toString("utf8")).includes("scomp.live."),
+      );
+      assert.ok(feedStartReply);
+
+      await waitFor(() => fake.channel.publish.mock.calls.length > 0);
+      const firstChunk = JSON.parse(
+        Buffer.from(fake.channel.publish.mock.calls[0][2]).toString("utf8"),
+      ) as { type?: string; payload?: unknown };
+      assert.equal(firstChunk.type, "next");
+      assert.deepEqual(firstChunk.payload, { id: 1 });
+    }
   });
 
   it("supports pluggable serializer and custom content type", async () => {

--- a/packages/transport-websocket-server/test/websocket-transport.spec.ts
+++ b/packages/transport-websocket-server/test/websocket-transport.spec.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { createServer, type Server as HttpServer } from "node:http";
 import type { AddressInfo } from "node:net";
-import { type CompiledRoute, type CompiledRouter } from "@scomp/core";
+import {
+  composeScompFragments,
+  createScompFragment,
+  createScompService,
+  type CompiledRoute,
+  type CompiledRouter,
+} from "@scomp/core";
 import { WebSocketClientTransport } from "@scomp/transport-websocket-client";
 import { WebSocketServerTransport } from "../src";
 
@@ -9,10 +15,8 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function collect(
-  iterable: AsyncIterable<number>,
-): Promise<Array<number>> {
-  const values: Array<number> = [];
+async function collect<T>(iterable: AsyncIterable<T>): Promise<Array<T>> {
+  const values: Array<T> = [];
   for await (const value of iterable) {
     values.push(value);
   }
@@ -95,6 +99,102 @@ async function closeClientTransport(
 }
 
 describe("WebSocket transports", () => {
+  it("keeps grouped and composed fragment routers transport-compatible", async () => {
+    interface UsersContract {
+      getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+      notifyLogin(input: { id: number }): Promise<void>;
+      liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
+    }
+
+    const groupedSignals: Array<unknown> = [];
+    const grouped = createScompService<UsersContract>("users").implement({
+      requests: {
+        getUser: async ({ id }: { id: number }) => ({ id, name: `u-${id}` }),
+      },
+      signals: {
+        notifyLogin: async (payload: { id: number }) => {
+          groupedSignals.push(payload);
+        },
+      },
+      feeds: {
+        liveUsers: {
+          strategy: "fanout",
+          hashKey: ({ room }: { room: string }) => room,
+          handler: async function* () {
+            yield { id: 1 };
+            yield { id: 2 };
+          },
+        },
+      },
+    });
+
+    const composedSignals: Array<unknown> = [];
+    const requestFragment = createScompFragment<UsersContract>("users").implement(
+      {
+        requests: {
+          getUser: async ({ id }: { id: number }) => ({ id, name: `u-${id}` }),
+        },
+      },
+    );
+    const signalFragment = createScompFragment<UsersContract>("users").implement(
+      {
+        signals: {
+          notifyLogin: async (payload: { id: number }) => {
+            composedSignals.push(payload);
+          },
+        },
+      },
+    );
+    const feedFragment = createScompFragment<UsersContract>("users").implement({
+      feeds: {
+        liveUsers: {
+          strategy: "fanout",
+          hashKey: ({ room }: { room: string }) => room,
+          handler: async function* () {
+            yield { id: 1 };
+            yield { id: 2 };
+          },
+        },
+      },
+    });
+    const composed = composeScompFragments(
+      requestFragment,
+      signalFragment,
+      feedFragment,
+    );
+
+    const cases = [
+      { router: grouped.router, signals: groupedSignals },
+      { router: composed.router, signals: composedSignals },
+    ];
+
+    for (const { router, signals } of cases) {
+      assert.equal(router["users.getUser"].kind, "request");
+      assert.equal(router["users.notifyLogin"].kind, "signal");
+      assert.equal(router["users.liveUsers"].kind, "feed");
+
+      const harness = await createHarness(router);
+      const client = new WebSocketClientTransport({ url: harness.url });
+
+      try {
+        const requestResult = await client.request("users.getUser", { id: 7 });
+        assert.deepEqual(requestResult, { id: 7, name: "u-7" });
+
+        await client.signal("users.notifyLogin", { id: 7 });
+        await wait(15);
+        assert.deepEqual(signals, [{ id: 7 }]);
+
+        const feedValues = await collect(client.feed("users.liveUsers", {
+          room: "general",
+        }));
+        assert.deepEqual(feedValues, [{ id: 1 }, { id: 2 }]);
+      } finally {
+        await closeClientTransport(client);
+        await closeHarness(harness);
+      }
+    }
+  });
+
   it("supports request, signal, and feed end-to-end", async () => {
     const signals: Array<unknown> = [];
 


### PR DESCRIPTION
## Summary
- Enforces strict-by-default grouped service authoring with compile-time method placement, signature, and completeness validation.
- Supports composable **fragments** for partial domain authoring and deterministic composition with duplicate-method rejection.
- Preserves transport/client compatibility for compiled routes/intents, with updated docs/examples/tests as the default workflow.
- Includes non-functional internal refactor scope (`scomp-sef.10`) for SOLID/DRY maintainability: extracted shared compiled-route assembly, reduced grouped input alias duplication, and clarified composition/compilation boundaries with no public API behavior change.

## Scope
- Epic bead: `scomp-sef`
- Child beads included in this epic PR: `scomp-sef.1`, `scomp-sef.2`, `scomp-sef.3`, `scomp-sef.4`, `scomp-sef.5`, `scomp-sef.6`, `scomp-sef.7`, `scomp-sef.8`, `scomp-sef.9`, `scomp-sef.10`

## Progress Checklist (Epic `scomp-sef`)
- [x] `scomp-sef.1` Design API: grouped strict service authoring
- [x] `scomp-sef.2` Implement strict service finalization
- [x] `scomp-sef.3` Add domain fragments and composition
- [x] `scomp-sef.4` Expand test coverage for strict authoring model
- [x] `scomp-sef.5` Validate routes/intents compatibility with transports
- [x] `scomp-sef.6` Enforce duplicate method rejection in composition
- [x] `scomp-sef.7` Update docs and examples to new default authoring model
- [x] `scomp-sef.8` Terminology update: use mixins instead of fragments (historical)
- [x] `scomp-sef.9` Terminology correction: fragments as primary term
- [x] `scomp-sef.10` Refactor builder internals for SOLID and DRY (non-functional)

## Status
- All child beads for epic `scomp-sef` are verified, including follow-up refactor bead `scomp-sef.10`.
- PR remains ready for review.