### PR TITLE
feat(transport-websocket-server): add Bun.serve websocket server transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,28 @@ See `apps/demo` for end-to-end examples using grouped sections and fragments.
 Transport protocol reference:
 
 - [docs/transport-json-protocol.md](docs/transport-json-protocol.md)
+
+## Bun websocket server transport
+
+`@scomp/transport-websocket-server` now includes a Bun-native server transport for `Bun.serve`.
+
+Use `createBunWebSocketServerTransport` to wire route handling without changing the existing envelope schema (`request`, `signal`, `feed_start`/`feed_stop` + feed chunk stream):
+
+```ts
+import { createBunWebSocketServerTransport } from "@scomp/transport-websocket-server";
+
+const transport = createBunWebSocketServerTransport({ path: "/ws" });
+await transport.listen(router);
+
+const server = Bun.serve({
+  port: 3000,
+  fetch: transport.fetch,
+  websocket: transport.websocket,
+});
+```
+
+Compatibility notes:
+
+- Existing Node + `ws` `WebSocketServerTransport` exports and behavior are unchanged.
+- Bun transport keeps the same request/signal/feed semantics and security policy hooks.
+- No protocol envelope changes are required for existing websocket clients.

--- a/packages/transport-websocket-server/jest.config.cjs
+++ b/packages/transport-websocket-server/jest.config.cjs
@@ -2,6 +2,7 @@ const { createJestConfig } = require("../../jest.base.cjs");
 
 module.exports = createJestConfig({
   rootDir: __dirname,
+  testMatch: ["**/*.spec.ts", "!**/*.bun.spec.ts"],
   moduleNameMapper: {
     "^@scomp/core$": "<rootDir>/../core/src",
     "^@scomp/types$": "<rootDir>/../types/src",

--- a/packages/transport-websocket-server/src/index.ts
+++ b/packages/transport-websocket-server/src/index.ts
@@ -52,6 +52,8 @@ interface SocketWithPrincipal extends WebSocket {
 
 type RouterTable = Record<string, CompiledRoute>;
 
+const WS_OPEN_STATE = 1;
+
 function safeJsonParse(text: string): any {
   try {
     return JSON.parse(text);
@@ -76,6 +78,28 @@ function toText(data: RawData): string {
   return Buffer.from(data).toString("utf8");
 }
 
+function toTextFromBunMessage(data: unknown): string {
+  if (typeof data === "string") {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString("utf8");
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString(
+      "utf8",
+    );
+  }
+
+  if (data === null || data === undefined) {
+    return "";
+  }
+
+  return String(data);
+}
+
 function toFeedExchange(hash: string): string {
   return `scomp.live.${hash}`;
 }
@@ -90,6 +114,58 @@ function ensureFeedIterable(value: unknown): AsyncIterable<unknown> {
   }
 
   throw new Error("Feed route handler did not return an AsyncIterable.");
+}
+
+interface BunWebSocketLike<Data extends object = Record<string, unknown>> {
+  readonly data: Data;
+  readonly readyState?: number;
+  send(message: string): unknown;
+}
+
+interface BunUpgradeServer {
+  upgrade(
+    request: Request,
+    options?: {
+      data?: Record<string, unknown>;
+    },
+  ): boolean;
+}
+
+type BunFetchHandler = (
+  request: Request,
+  server: BunUpgradeServer,
+) => Response | void | Promise<Response | void>;
+
+interface BunWebSocketHandler {
+  open?: (socket: BunWebSocketLike<BunSocketState>) => void;
+  message?: (socket: BunWebSocketLike<BunSocketState>, message: unknown) => void;
+  close?: (
+    socket: BunWebSocketLike<BunSocketState>,
+    code: number,
+    reason: string,
+  ) => void;
+}
+
+interface BunSocketState {
+  scompPrincipal?: ScompTransportPrincipal;
+}
+
+interface BunRunningFeed {
+  key: string;
+  exchange: string;
+  subscribers: Set<BunWebSocketLike<BunSocketState>>;
+  abortController: AbortController;
+}
+
+interface BunSocketWithPrincipal extends BunWebSocketLike<BunSocketState> {
+  data: BunSocketState;
+}
+
+export interface BunWebSocketServerTransportConfig {
+  path?: string;
+  outbound?: WebSocketClientTransportConfig | WebSocketClientTransport;
+  security?: ScompTransportSecurityPolicy;
+  onHttpRequest?: (request: Request) => Response | Promise<Response>;
 }
 
 export class WebSocketServerTransport implements ITransport {
@@ -509,8 +585,435 @@ export class WebSocketServerTransport implements ITransport {
   }
 }
 
+export class BunWebSocketServerTransport implements ITransport {
+  private readonly config: BunWebSocketServerTransportConfig;
+  private readonly path: string;
+  private router?: RouterTable;
+  private readonly sockets = new Set<BunWebSocketLike<BunSocketState>>();
+  private readonly runningFeeds = new Map<string, BunRunningFeed>();
+  private outboundTransport?: ITransport;
+
+  readonly fetch: BunFetchHandler;
+  readonly websocket: BunWebSocketHandler;
+
+  constructor(config: BunWebSocketServerTransportConfig = {}) {
+    this.config = config;
+    this.path = config.path ?? "/";
+    this.fetch = this.handleFetch.bind(this);
+    this.websocket = {
+      open: this.handleOpen.bind(this),
+      message: this.handleMessage.bind(this),
+      close: this.handleClose.bind(this),
+    };
+  }
+
+  async listen(router: RouterTable): Promise<void> {
+    this.router = router;
+  }
+
+  async request(
+    route: string,
+    payload: any,
+    options?: ScompClientInvokeOptions,
+  ): Promise<any> {
+    const transport = this.getOutboundTransport();
+    return transport.request(route, payload, options);
+  }
+
+  async signal(
+    route: string,
+    payload: any,
+    options?: ScompClientInvokeOptions,
+  ): Promise<void> {
+    const transport = this.getOutboundTransport();
+    await transport.signal(route, payload, options);
+  }
+
+  feed(
+    route: string,
+    payload: any,
+    options?: ScompClientInvokeOptions,
+  ): AsyncIterable<any> {
+    const transport = this.getOutboundTransport();
+    return transport.feed(route, payload, options);
+  }
+
+  private getOutboundTransport(): ITransport {
+    if (this.outboundTransport) {
+      return this.outboundTransport;
+    }
+
+    const outboundConfig = this.config.outbound;
+    if (!outboundConfig) {
+      throw new Error(
+        "BunWebSocketServerTransport outbound is not configured. Provide config.outbound to use request/signal/feed.",
+      );
+    }
+
+    this.outboundTransport =
+      outboundConfig instanceof WebSocketClientTransport
+        ? outboundConfig
+        : new WebSocketClientTransport(outboundConfig);
+
+    return this.outboundTransport;
+  }
+
+  private async handleFetch(
+    request: Request,
+    server: BunUpgradeServer,
+  ): Promise<Response | void> {
+    const pathname = new URL(request.url).pathname;
+    if (pathname !== this.path) {
+      if (this.config.onHttpRequest) {
+        return this.config.onHttpRequest(request);
+      }
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const upgraded = server.upgrade(request, {
+      data: {},
+    });
+
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 400 });
+    }
+
+    return;
+  }
+
+  private handleOpen(socket: BunWebSocketLike<BunSocketState>): void {
+    this.sockets.add(socket);
+  }
+
+  private handleMessage(
+    socket: BunWebSocketLike<BunSocketState>,
+    message: unknown,
+  ): void {
+    const body = safeJsonParse(toTextFromBunMessage(message)) as TransportMessage;
+    void this.handleIncoming(socket as BunSocketWithPrincipal, body);
+  }
+
+  private handleClose(socket: BunWebSocketLike<BunSocketState>): void {
+    this.detachSocketFromFeeds(socket);
+    this.sockets.delete(socket);
+  }
+
+  private async handleIncoming(
+    socket: BunSocketWithPrincipal,
+    body: TransportMessage,
+  ): Promise<void> {
+    const routeName = String(body.route ?? "");
+    const routeEntry = this.router?.[routeName];
+    const op = body.op ?? "request";
+
+    const { allowed, principal } = await this.checkSecurity(socket, {
+      direction: "inbound",
+      transport: "websocket",
+      route: routeName,
+      operation: op,
+      payload: body.payload,
+      meta: body.meta,
+    });
+
+    if (!allowed) {
+      if (body.id) {
+        this.replyWithError(
+          socket,
+          body.id,
+          `Inbound operation not authorized for route: ${routeName}`,
+          this.toPrincipalMeta(principal),
+        );
+      }
+      return;
+    }
+
+    if (!routeEntry) {
+      if (body.id) {
+        this.replyWithError(
+          socket,
+          body.id,
+          `Route not found: ${routeName}`,
+          this.toPrincipalMeta(principal),
+        );
+      }
+      return;
+    }
+
+    if (routeEntry.kind === "feed") {
+      await this.handleFeedRpc(socket, routeEntry, body, op);
+      return;
+    }
+
+    if (op === "signal" || routeEntry.kind === "signal") {
+      try {
+        await this.invokeRoute(routeEntry, body);
+      } catch {
+        // Signals are fire-and-forget and do not reply.
+      }
+      return;
+    }
+
+    try {
+      const result = await this.invokeRoute(routeEntry, body);
+      this.replyWithPayload(
+        socket,
+        body.id,
+        result,
+        this.toPrincipalMeta(principal),
+      );
+    } catch (error) {
+      this.replyWithError(
+        socket,
+        body.id,
+        error,
+        this.toPrincipalMeta(principal),
+      );
+    }
+  }
+
+  private async handleFeedRpc(
+    socket: BunWebSocketLike<BunSocketState>,
+    route: CompiledRoute,
+    body: TransportMessage,
+    op: string,
+  ): Promise<void> {
+    const rawPayload = body.payload;
+    const parsedPayload = route.parser ? route.parser(rawPayload) : rawPayload;
+    const payloadRecord =
+      body.payload && typeof body.payload === "object"
+        ? (body.payload as { hash?: unknown })
+        : undefined;
+    const hash = String(
+      payloadRecord?.hash ??
+        createFeedHash(route.route, parsedPayload, { hashKey: route.hashKey }),
+    );
+
+    if (op === "feed_stop") {
+      const running = this.runningFeeds.get(hash);
+      if (running) {
+        running.subscribers.delete(socket);
+        if (running.subscribers.size === 0) {
+          running.abortController.abort(new StreamClosedError(hash));
+        }
+      }
+
+      this.replyWithPayload(socket, body.id, { ok: true });
+      return;
+    }
+
+    const existing = this.runningFeeds.get(hash);
+    if (existing) {
+      existing.subscribers.add(socket);
+      this.replyWithPayload(socket, body.id, {
+        exchange: existing.exchange,
+        hash,
+      });
+      return;
+    }
+
+    const runningFeed: BunRunningFeed = {
+      key: hash,
+      exchange: toFeedExchange(hash),
+      subscribers: new Set([socket]),
+      abortController: new AbortController(),
+    };
+
+    this.runningFeeds.set(hash, runningFeed);
+    this.replyWithPayload(socket, body.id, {
+      exchange: runningFeed.exchange,
+      hash,
+    });
+
+    const iterable = ensureFeedIterable(route.handler(parsedPayload));
+    queueMicrotask(() => {
+      void this.publishFeed(runningFeed, iterable);
+    });
+  }
+
+  private async publishFeed(
+    runningFeed: BunRunningFeed,
+    iterable: AsyncIterable<unknown>,
+  ): Promise<void> {
+    try {
+      for await (const chunk of iterable) {
+        if (runningFeed.abortController.signal.aborted) {
+          throw runningFeed.abortController.signal.reason;
+        }
+
+        this.broadcastFeedChunk(runningFeed, {
+          hash: runningFeed.key,
+          type: "next",
+          payload: chunk,
+        });
+      }
+
+      this.broadcastFeedChunk(runningFeed, {
+        hash: runningFeed.key,
+        type: "done",
+      });
+    } catch (error) {
+      this.broadcastFeedChunk(runningFeed, {
+        hash: runningFeed.key,
+        type: "error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      this.runningFeeds.delete(runningFeed.key);
+    }
+  }
+
+  private broadcastFeedChunk(
+    runningFeed: BunRunningFeed,
+    chunk: {
+      hash: string;
+      type: "next" | "done" | "error";
+      payload?: unknown;
+      message?: string;
+    },
+  ): void {
+    const payload = JSON.stringify({
+      channel: "feed",
+      ...chunk,
+    } satisfies ScompFeedChunkEnvelope);
+
+    for (const socket of runningFeed.subscribers) {
+      if (socket.readyState !== undefined && socket.readyState !== WS_OPEN_STATE) {
+        continue;
+      }
+
+      socket.send(payload);
+    }
+  }
+
+  private detachSocketFromFeeds(socket: BunWebSocketLike<BunSocketState>): void {
+    for (const runningFeed of this.runningFeeds.values()) {
+      if (!runningFeed.subscribers.has(socket)) {
+        continue;
+      }
+
+      runningFeed.subscribers.delete(socket);
+      if (runningFeed.subscribers.size === 0) {
+        runningFeed.abortController.abort(new StreamClosedError(runningFeed.key));
+      }
+    }
+  }
+
+  private async invokeRoute(
+    route: CompiledRoute,
+    message: TransportMessage,
+  ): Promise<unknown> {
+    const rawPayload = message.payload;
+    const payload = route.parser ? route.parser(rawPayload) : rawPayload;
+    return route.handler(payload);
+  }
+
+  private replyWithPayload(
+    socket: BunWebSocketLike<BunSocketState>,
+    id: string | undefined,
+    payload: unknown,
+    meta?: ScompTransportMessageMeta,
+  ): void {
+    if (!id) {
+      return;
+    }
+
+    if (socket.readyState !== undefined && socket.readyState !== WS_OPEN_STATE) {
+      return;
+    }
+
+    socket.send(
+      JSON.stringify({
+        id,
+        payload,
+        meta,
+      } satisfies ScompTransportResponseEnvelope),
+    );
+  }
+
+  private replyWithError(
+    socket: BunWebSocketLike<BunSocketState>,
+    id: string | undefined,
+    error: unknown,
+    meta?: ScompTransportMessageMeta,
+  ): void {
+    if (!id) {
+      return;
+    }
+
+    if (socket.readyState !== undefined && socket.readyState !== WS_OPEN_STATE) {
+      return;
+    }
+
+    socket.send(
+      JSON.stringify({
+        id,
+        error: error instanceof Error ? error.message : String(error),
+        meta,
+      } satisfies ScompTransportResponseEnvelope),
+    );
+  }
+
+  private toPrincipalMeta(
+    principal: ScompTransportPrincipal | undefined,
+  ): ScompTransportMessageMeta | undefined {
+    if (!principal) {
+      return undefined;
+    }
+
+    return {
+      auth: {
+        subject: principal.subject,
+        tenantId: principal.tenantId,
+        scopes: principal.scopes,
+        claims: principal.claims,
+        issuedAt: principal.issuedAt,
+        expiresAt: principal.expiresAt,
+        authType: principal.authType,
+      },
+      tenantId: principal.tenantId,
+    };
+  }
+
+  private async checkSecurity(
+    socket: BunSocketWithPrincipal,
+    ctx: Omit<ScompTransportSecurityContext, "principal">,
+  ): Promise<{ allowed: boolean; principal?: ScompTransportPrincipal }> {
+    const policy = this.config.security;
+    if (!policy) {
+      return { allowed: true, principal: socket.data.scompPrincipal };
+    }
+
+    const principal = policy.authenticate
+      ? await policy.authenticate(ctx)
+      : (socket.data.scompPrincipal ?? undefined);
+
+    if (principal) {
+      socket.data.scompPrincipal = principal;
+    }
+
+    if (!policy.authorize) {
+      return { allowed: true, principal: principal ?? undefined };
+    }
+
+    const allowed = Boolean(
+      await policy.authorize({
+        ...ctx,
+        principal: principal ?? undefined,
+      }),
+    );
+
+    return { allowed, principal: principal ?? undefined };
+  }
+}
+
 export function createWebSocketServerTransport(
   config: WebSocketServerTransportConfig,
 ): WebSocketServerTransport {
   return new WebSocketServerTransport(config);
+}
+
+export function createBunWebSocketServerTransport(
+  config: BunWebSocketServerTransportConfig = {},
+): BunWebSocketServerTransport {
+  return new BunWebSocketServerTransport(config);
 }

--- a/packages/transport-websocket-server/test/websocket-transport.bun.spec.ts
+++ b/packages/transport-websocket-server/test/websocket-transport.bun.spec.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from "bun:test";
+import type { CompiledRoute } from "@scomp/core";
+import type { ScompTransportSecurityPolicy } from "@scomp/types";
+import {
+  createBunWebSocketServerTransport,
+  type BunWebSocketServerTransport,
+} from "../src";
+
+declare const Bun: {
+  serve(options: {
+    port: number;
+    fetch: (request: Request, server: { upgrade(request: Request, options?: { data?: Record<string, unknown> }): boolean }) => Response | Promise<Response> | void | Promise<void>;
+    websocket: {
+      open?: (...args: Array<any>) => void;
+      message?: (...args: Array<any>) => void;
+      close?: (...args: Array<any>) => void;
+    };
+  }): {
+    port: number;
+    stop(closeActiveConnections?: boolean): void;
+  };
+};
+
+type OpenSocket = WebSocket & { readyState: number };
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function openSocket(url: string): Promise<OpenSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url) as OpenSocket;
+    socket.addEventListener("open", () => resolve(socket), { once: true });
+    socket.addEventListener("error", () => reject(new Error("Socket open failed")), {
+      once: true,
+    });
+  });
+}
+
+function sendJson(socket: OpenSocket, body: unknown): void {
+  socket.send(JSON.stringify(body));
+}
+
+function waitForRpcResponse(socket: OpenSocket, id: string): Promise<any> {
+  return new Promise((resolve) => {
+    const listener = (event: MessageEvent<string>) => {
+      const payload = JSON.parse(String(event.data));
+      if (payload.id !== id) {
+        return;
+      }
+
+      socket.removeEventListener("message", listener as EventListener);
+      resolve(payload);
+    };
+
+    socket.addEventListener("message", listener as EventListener);
+  });
+}
+
+function waitForFeedChunks(
+  socket: OpenSocket,
+  hash: string,
+): Promise<Array<Record<string, unknown>>> {
+  return new Promise((resolve) => {
+    const chunks: Array<Record<string, unknown>> = [];
+    const listener = (event: MessageEvent<string>) => {
+      const payload = JSON.parse(String(event.data)) as Record<string, unknown>;
+      if (payload.channel !== "feed" || payload.hash !== hash) {
+        return;
+      }
+
+      chunks.push(payload);
+      if (payload.type === "done") {
+        socket.removeEventListener("message", listener as EventListener);
+        resolve(chunks);
+      }
+    };
+
+    socket.addEventListener("message", listener as EventListener);
+  });
+}
+
+async function createBunHarness(
+  router: Record<string, CompiledRoute>,
+  options?: {
+    security?: ScompTransportSecurityPolicy;
+  },
+): Promise<{
+  transport: BunWebSocketServerTransport;
+  server: {
+    port: number;
+    stop(closeActiveConnections?: boolean): void;
+  };
+  url: string;
+}> {
+  const transport = createBunWebSocketServerTransport({
+    path: "/ws",
+    security: options?.security,
+  });
+  await transport.listen(router);
+
+  const server = Bun.serve({
+    port: 0,
+    fetch: transport.fetch as unknown as (
+      request: Request,
+      server: {
+        upgrade(
+          request: Request,
+          options?: { data?: Record<string, unknown> },
+        ): boolean;
+      },
+    ) => Response | Promise<Response> | void | Promise<void>,
+    websocket: transport.websocket,
+  });
+
+  return {
+    transport,
+    server,
+    url: `ws://127.0.0.1:${server.port}/ws`,
+  };
+}
+
+describe("BunWebSocketServerTransport", () => {
+  it("boots with Bun.serve and handles request/signal/feed envelopes", async () => {
+    const seenSignals: Array<unknown> = [];
+    const router: Record<string, CompiledRoute> = {
+      "math.double": {
+        route: "math.double",
+        kind: "request",
+        handler: async (value: number) => value * 2,
+      },
+      "math.notify": {
+        route: "math.notify",
+        kind: "signal",
+        handler: async (payload: unknown) => {
+          seenSignals.push(payload);
+        },
+      },
+      "math.count": {
+        route: "math.count",
+        kind: "feed",
+        strategy: "fanout",
+        handler: async function* (limit: number) {
+          for (let value = 1; value <= limit; value += 1) {
+            yield value;
+          }
+        },
+      },
+    };
+
+    const harness = await createBunHarness(router);
+    const socket = await openSocket(harness.url);
+
+    try {
+      const requestId = "req-1";
+      const requestResponsePromise = waitForRpcResponse(socket, requestId);
+      sendJson(socket, {
+        id: requestId,
+        route: "math.double",
+        op: "request",
+        payload: 21,
+      });
+
+      const requestResponse = await requestResponsePromise;
+      expect(requestResponse.payload).toBe(42);
+
+      sendJson(socket, {
+        id: "sig-1",
+        route: "math.notify",
+        op: "signal",
+        payload: { id: 7 },
+      });
+      await wait(20);
+      expect(seenSignals).toEqual([{ id: 7 }]);
+
+      const feedStartId = "feed-start-1";
+      const feedStartPromise = waitForRpcResponse(socket, feedStartId);
+      sendJson(socket, {
+        id: feedStartId,
+        route: "math.count",
+        op: "feed_start",
+        payload: 3,
+      });
+
+      const feedStart = await feedStartPromise;
+      const hash = String(feedStart.payload?.hash ?? "");
+      expect(hash.length).toBeGreaterThan(0);
+
+      const feedChunks = await waitForFeedChunks(socket, hash);
+      expect(feedChunks.map((chunk) => chunk.type)).toEqual([
+        "next",
+        "next",
+        "next",
+        "done",
+      ]);
+      expect(
+        feedChunks
+          .filter((chunk) => chunk.type === "next")
+          .map((chunk) => chunk.payload),
+      ).toEqual([1, 2, 3]);
+    } finally {
+      socket.close();
+      harness.server.stop(true);
+    }
+  });
+
+  it("rejects unauthorized inbound requests via security policy", async () => {
+    const deniedSignals: Array<unknown> = [];
+
+    const router: Record<string, CompiledRoute> = {
+      "secure.echo": {
+        route: "secure.echo",
+        kind: "request",
+        handler: async (payload: unknown) => ({ payload }),
+      },
+      "secure.signal": {
+        route: "secure.signal",
+        kind: "signal",
+        handler: async (payload: unknown) => {
+          deniedSignals.push(payload);
+        },
+      },
+    };
+
+    const harness = await createBunHarness(router, {
+      security: {
+        authenticate: ({ meta }: { meta?: { auth?: { token?: string } } }) => {
+          const auth = meta?.auth as { token?: string } | undefined;
+          if (auth?.token === "allow") {
+            return { subject: "user:allow" };
+          }
+
+          return null;
+        },
+        authorize: (ctx: { principal?: { subject?: string } }) =>
+          ctx.principal?.subject === "user:allow",
+      },
+    });
+
+    const deniedSocket = await openSocket(harness.url);
+    const allowedSocket = await openSocket(harness.url);
+
+    try {
+      const deniedRequestId = "denied-req";
+      const deniedResponsePromise = waitForRpcResponse(deniedSocket, deniedRequestId);
+      sendJson(deniedSocket, {
+        id: deniedRequestId,
+        route: "secure.echo",
+        op: "request",
+        payload: { id: 1 },
+        meta: { auth: { token: "deny" } },
+      });
+      const deniedResponse = await deniedResponsePromise;
+      expect(String(deniedResponse.error)).toContain("not authorized");
+
+      const allowedRequestId = "allowed-req";
+      const allowedResponsePromise = waitForRpcResponse(allowedSocket, allowedRequestId);
+      sendJson(allowedSocket, {
+        id: allowedRequestId,
+        route: "secure.echo",
+        op: "request",
+        payload: { id: 2 },
+        meta: { auth: { token: "allow" } },
+      });
+      const allowedResponse = await allowedResponsePromise;
+      expect(allowedResponse.payload).toEqual({ payload: { id: 2 } });
+
+      sendJson(deniedSocket, {
+        id: "denied-signal",
+        route: "secure.signal",
+        op: "signal",
+        payload: { denied: true },
+        meta: { auth: { token: "deny" } },
+      });
+      await wait(20);
+      expect(deniedSignals).toEqual([]);
+    } finally {
+      deniedSocket.close();
+      allowedSocket.close();
+      harness.server.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Bun-native websocket server transport for `Bun.serve` in `@scomp/transport-websocket-server`.
- Preserve existing Node/`ws` transport behavior and keep request/signal/feed envelope semantics unchanged.
- Add Bun runtime coverage for startup + route handling and document Bun usage/compatibility in `README.md`.

## Scope
- Epic bead: `scomp-7ji`
- Child beads included in this epic PR: `scomp-7ji`

## Progress Checklist (Epic `scomp-7ji`)
- [x] `scomp-7ji` Add Bun-native websocket server transport for Bun.serve

## Validation
- [x] `bun x turbo run build --filter=@scomp/transport-websocket-server...`
- [x] `bun x turbo run test --filter=@scomp/transport-websocket-server`
- [x] `bun test packages/transport-websocket-server/test/websocket-transport.bun.spec.ts`

## Status
- Bead `scomp-7ji` is `in_review`.
- Draft PR is ready for review.