### PR TITLE
feat: browser transport parity across runtimes (scomp-vbj)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,117 @@
 # SCOMP
 
-RPC experiment
+SCOMP is a transport-agnostic RPC toolkit with first-class `request`, `signal`, and `feed` semantics.
 
-## Concepts
+This branch aligns browser usage with current parity guarantees so docs and demos match implemented behavior.
 
-- Unary
+## Packages
 
-service()
+- `@scomp/client` – typed client proxy API with per-call invocation options.
+- `@scomp/core` – service/router primitives.
+- `@scomp/transport-rabbitmq` – RabbitMQ transport.
+- `@scomp/transport-websocket-server` – WebSocket server transport for hosting routes.
+- `@scomp/transport-websocket-browser` – browser WebSocket client transport.
 
-## Usage
+## Browser transport quickstart
 
-```javascript
-  const scomp = new Scomp(new SocketIOWire(io));
-  const client = scomp.client();
+Use `@scomp/transport-websocket-browser` in browser-like runtimes and pair it with a server transport (for example `@scomp/transport-websocket-server`) that hosts routes.
 
-  // void result function
-  scomp.call(client.saft.get('console').log('Hey ho!'));
+```ts
+import { createScompClient, type ClientRouteHints } from "@scomp/client";
+import { createWebSocketBrowserTransport } from "@scomp/transport-websocket-browser";
 
-  // void result function ($ always initiates a call, or rename to then to be more promise like)
-  client.saft.get('console').log('Hey ho!').$();
+type ApiContract = {
+  users: {
+    getUser(input: { id: number }): Promise<{ id: number; name: string }>;
+    notifyLogin(input: { userId: number; at: string }): Promise<void>;
+    liveTicker(input: { channel: string }): AsyncIterable<{ sequence: number }>;
+  };
+};
 
-  // return from promise
-  client.viewdb.collection('order').findByPromise({}).$()
-    .then(console.log);
-  // shortcut to just use .then() <-- trigger call
-  client.viewdb.collection('order').findByPromise({})
-    .then(console.log);
+const routeHints: ClientRouteHints = {
+  "users.getUser": "request",
+  "users.notifyLogin": "signal",
+  "users.liveTicker": "feed",
+};
 
-// return stream
-  client.viewdb.collection('order').find({}).toArray(scomp.callback()).$()
-    .on('data', data=>{}) // data element
-    .on('end', ()=>{}) // other side terminated stream
-    ;  
-  ```
+const transport = createWebSocketBrowserTransport({
+  url: "ws://127.0.0.1:3399",
+  meta: {
+    traceId: "browser-trace",
+    tags: { source: "browser" },
+  },
+});
 
-## Wire format
+const client = createScompClient<ApiContract>({ transport, routeHints });
 
-Current protocol reference for the new transport stack:
-- See [docs/transport-json-protocol.md](docs/transport-json-protocol.md)
+const user = await client.users.getUser(
+  { id: 1 },
+  {
+    meta: { tenantId: "tenant-a" },
+    priority: "P1",
+    priorityClass: "P2",
+    deadlineAtMs: Date.now() + 1_000,
+    targetLatencyMs: 40,
+  },
+);
 
-### Request Client -> Server
+await client.users.notifyLogin({ userId: user.id, at: new Date().toISOString() });
 
-```json
-{
-  "id": 123123121,
-  "req": {
-    "s": "saft",
-    "p":[ "eh", "oh"]
-  }
+for await (const tick of client.users.liveTicker({ channel: "prices" })) {
+  console.log(tick);
+  break;
 }
 ```
 
-### Response Server -> Client
+## Browser parity guarantees
 
-```json
-{
-  "id": 123123121, // corresponds to
-  "res": {}, // user data
-  "str": {}, // stream control data
-  "err": {} // error
-}
-```
+`@scomp/transport-websocket-browser` now matches server/client transports for invocation envelope behavior:
 
-### Stream Control (Most commony Server -> Client)
+- `request`, `signal`, `feed_start`, and `feed_stop` all carry invocation options.
+- Metadata merge order is deterministic: `config.meta` -> `call meta` -> priority hints -> authenticated principal metadata.
+- Priority hints (`priority`, `priorityClass`, `deadlineAtMs`, `targetLatencyMs`) are serialized into envelope `meta`.
+- Feed stop uses the same metadata shape as feed start when invoked from the same call context.
 
-```json
-{
-  "id": 123123123, // corresponds to
-  "seq": 0, // sequence of events, start at 0
-  "res": {}, // user data
-  "str": {}, // stream control data
-  "err": {} // error
-}
-```
+## Security behavior and caveats
+
+Both browser and WebSocket server transports support `security.authenticate` and `security.authorize` hooks.
+
+- Browser transport hooks run before sending outbound envelopes.
+- Server transport hooks run for inbound envelopes before route dispatch.
+- If authorization denies an operation, the operation is rejected and no outbound frame is sent (browser client behavior).
+
+Important caveats:
+
+- Browser-side hooks are best-effort client policy controls, not a trust boundary.
+- `meta.auth` is opaque and transport-agnostic; verify and enforce identity server-side.
+- Priority hints are advisory metadata unless a transport/policy explicitly enforces scheduling behavior.
+
+## Migration notes (browser websocket)
+
+If you were using browser WebSocket transport before parity updates, align to the following:
+
+1. Depend on `@scomp/transport-websocket-browser` for browser clients.
+2. Pass invocation options on client calls when needed:
+   - `meta`
+   - `priority`
+   - `priorityClass`
+   - `deadlineAtMs`
+   - `targetLatencyMs`
+3. Expect these options to be present on request/signal/feed envelopes.
+4. Keep authorization and identity enforcement on trusted server-side transports.
+
+## Demo
+
+RabbitMQ demo entrypoint (existing):
+
+- `bun run --filter='@scomp/demo' start`
+
+Browser parity demo entrypoint:
+
+- `bun run --filter='@scomp/demo' run-browser`
+
+The browser demo uses WebSocket server + browser transport in one process and showcases request/signal/feed parity including metadata, priority hints, and security hooks.
+
+## Protocol reference
+
+- [docs/transport-json-protocol.md](docs/transport-json-protocol.md)

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -6,12 +6,18 @@
     "build": "tsc -b tsconfig.json",
     "lint": "echo \"No lint configured for @scomp/demo\"",
     "test": "echo \"No tests configured for @scomp/demo\"",
-    "start": "ts-node run.ts"
+    "start": "ts-node run.ts",
+    "run-browser": "bun run build && node dist/run-browser.js"
   },
   "dependencies": {
-    "@scomp/core": "workspace:*",
     "@scomp/client": "workspace:*",
+    "@scomp/core": "workspace:*",
     "@scomp/transport-rabbitmq": "workspace:*",
+    "@scomp/transport-websocket-browser": "workspace:*",
+    "@scomp/transport-websocket-server": "workspace:*",
     "@scomp/types": "workspace:*"
+  },
+  "devDependencies": {
+    "ws": "^8.18.3"
   }
 }

--- a/apps/demo/run-browser.ts
+++ b/apps/demo/run-browser.ts
@@ -1,0 +1,204 @@
+import {
+  createScompClient,
+  type ClientRouteHints,
+} from "@scomp/client";
+import { createScompService } from "@scomp/core";
+import { createWebSocketBrowserTransport } from "@scomp/transport-websocket-browser";
+import { createWebSocketServerTransport } from "@scomp/transport-websocket-server";
+import type {
+  ScompTransportSecurityContext,
+  ScompTransportSecurityPolicy,
+} from "@scomp/types";
+
+const WsWebSocket = require("ws") as any;
+import type {
+  DemoApiContract,
+  LiveTickerInput,
+  LiveTickerTick,
+} from "./shared/api.contract";
+
+const routeHints: ClientRouteHints = {
+  "users.getUser": "request",
+  "users.notifyLogin": "signal",
+  "users.liveTicker": "feed",
+};
+
+class WsBrowserAdapter {
+  private readonly socket: any;
+
+  constructor(url: string, protocols?: string | Array<string>) {
+    this.socket = new WsWebSocket(url, protocols as never);
+
+  }
+
+  get readyState(): number {
+    return this.socket.readyState;
+  }
+
+  send(payload: string): void {
+    this.socket.send(payload);
+  }
+
+  close(): void {
+    this.socket.close();
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    if (type === "message") {
+      this.socket.on("message", (data: unknown) => listener({ data }));
+      return;
+    }
+
+    this.socket.on(type as "open" | "close" | "error", listener as () => void);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    if (type === "message") {
+      this.socket.off("message", listener as (event: unknown) => void);
+      return;
+    }
+
+    this.socket.off(type as "open" | "close" | "error", listener as () => void);
+  }
+}
+
+const usersService = createScompService<DemoApiContract["users"]>("users").implement({
+  getUser: {
+    kind: "request",
+    parser: (payload: unknown): { id: number } => {
+      const input = payload as { id: number };
+      return { id: Number(input.id) };
+    },
+    handler: async (input: { id: number }) => ({
+      id: input.id,
+      name: `user-${input.id}`,
+    }),
+  },
+  notifyLogin: {
+    kind: "signal",
+    parser: (payload: unknown): { userId: number; at: string } => {
+      const input = payload as { userId: number; at: string };
+      return {
+        userId: Number(input.userId),
+        at: String(input.at),
+      };
+    },
+    handler: async (input: { userId: number; at: string }) => {
+      console.log("[browser-signal] user login notified", input);
+    },
+  },
+  liveTicker: {
+    kind: "feed",
+    strategy: "fanout",
+    hashKey: (input: LiveTickerInput) => input.channel,
+    handler: async function* (input: LiveTickerInput): AsyncIterable<LiveTickerTick> {
+      let sequence = 0;
+      try {
+        while (true) {
+          sequence += 1;
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          yield {
+            channel: input.channel,
+            sequence,
+            at: new Date().toISOString(),
+          };
+        }
+      } finally {
+        console.log("[browser-feed] teardown for channel", input.channel);
+      }
+    },
+  },
+});
+
+async function runBrowserDemo() {
+  const port = Number(process.env.SCOMP_BROWSER_DEMO_PORT ?? 3399);
+  const url = `ws://127.0.0.1:${port}`;
+
+  const securityPolicy: ScompTransportSecurityPolicy = {
+    authenticate: ({ operation }: Omit<ScompTransportSecurityContext, "principal">) => ({
+      subject: `browser-demo:${operation}`,
+      tenantId: "tenant-browser-demo",
+      claims: { source: "run-browser" },
+    }),
+    authorize: ({ route }: ScompTransportSecurityContext) =>
+      route.startsWith("users."),
+  };
+
+  const server = createWebSocketServerTransport({
+    port,
+    host: "127.0.0.1",
+    security: securityPolicy,
+  });
+  await server.listen(usersService.router);
+
+  const transport = createWebSocketBrowserTransport({
+    url,
+    webSocketCtor: WsBrowserAdapter as unknown as new (
+      url: string,
+      protocols?: string | Array<string>,
+    ) => any,
+    meta: {
+      traceId: "demo-browser-trace",
+      tags: { source: "demo-browser" },
+    },
+    security: {
+      authenticate: ({ operation }: Omit<ScompTransportSecurityContext, "principal">) => ({
+        subject: `client:${operation}`,
+        tenantId: "tenant-client",
+        claims: { source: "browser-client-hook" },
+      }),
+      authorize: ({ route }: ScompTransportSecurityContext) => route.startsWith("users."),
+    },
+  });
+
+  const client = createScompClient<DemoApiContract>({
+    transport,
+    routeHints,
+  });
+
+  const user = await client.users.getUser(
+    { id: 7 },
+    {
+      meta: { tenantId: "tenant-invoke", tags: { feature: "parity" } },
+      priority: "P0",
+      priorityClass: "P1",
+      deadlineAtMs: Date.now() + 1_000,
+      targetLatencyMs: 25,
+    },
+  );
+  console.log("browser request result:", user);
+
+  await client.users.notifyLogin(
+    { userId: user.id, at: new Date().toISOString() },
+    {
+      meta: { tenantId: "tenant-signal" },
+      priority: "P2",
+      targetLatencyMs: 60,
+    },
+  );
+  console.log("browser signal sent: users.notifyLogin");
+
+  let seen = 0;
+  for await (const tick of client.users.liveTicker(
+    { channel: "prices" },
+    {
+      meta: { tenantId: "tenant-feed" },
+      priority: "P1",
+      deadlineAtMs: Date.now() + 3_000,
+    },
+  )) {
+    console.log("browser feed chunk:", tick);
+    seen += 1;
+    if (seen >= 3) {
+      break;
+    }
+  }
+
+  console.log("browser feed stopped after 3 chunks");
+  process.exit(0);
+}
+
+void runBrowserDemo().catch((error) => {
+  console.error("run-browser failed", error);
+  process.exit(1);
+});

--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -2,6 +2,16 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@scomp/types": ["../../packages/types/src"],
+      "@scomp/core": ["../../packages/core/src"],
+      "@scomp/client": ["../../packages/client/src"],
+      "@scomp/transport-rabbitmq": ["../../packages/transport-rabbitmq/src"],
+      "@scomp/transport-websocket-browser": ["../../packages/transport-websocket-browser/src"],
+      "@scomp/transport-websocket-server": ["../../packages/transport-websocket-server/src"],
+      "@scomp/transport-websocket-client": ["../../packages/transport-websocket-client/src"]
+    },
     "rootDir": ".",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/.tsbuildinfo"
@@ -10,7 +20,15 @@
     { "path": "../../packages/types" },
     { "path": "../../packages/core" },
     { "path": "../../packages/client" },
-    { "path": "../../packages/transport-rabbitmq" }
+    { "path": "../../packages/transport-rabbitmq" },
+    { "path": "../../packages/transport-websocket-browser" },
+    { "path": "../../packages/transport-websocket-server" }
   ],
-  "include": ["run.ts", "backend/**/*", "frontend/**/*", "shared/**/*"]
+  "include": [
+    "run.ts",
+    "run-browser.ts",
+    "backend/**/*",
+    "frontend/**/*",
+    "shared/**/*"
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -93,11 +93,20 @@
         "amqplib": "^0.10.9",
       },
     },
+    "packages/transport-websocket-browser": {
+      "name": "@scomp/transport-websocket-browser",
+      "version": "0.1.0",
+      "dependencies": {
+        "@scomp/core": "workspace:*",
+        "@scomp/types": "workspace:*",
+      },
+    },
     "packages/transport-websocket-client": {
       "name": "@scomp/transport-websocket-client",
       "version": "0.1.0",
       "dependencies": {
         "@scomp/core": "workspace:*",
+        "@scomp/types": "workspace:*",
         "@types/ws": "^8.18.1",
         "ws": "^8.18.3",
       },
@@ -108,6 +117,7 @@
       "dependencies": {
         "@scomp/core": "workspace:*",
         "@scomp/transport-websocket-client": "workspace:*",
+        "@scomp/types": "workspace:*",
         "@types/ws": "^8.18.1",
         "ws": "^8.18.3",
       },
@@ -493,6 +503,8 @@
     "@scomp/transport-inprocess": ["@scomp/transport-inprocess@workspace:packages/transport-inprocess"],
 
     "@scomp/transport-rabbitmq": ["@scomp/transport-rabbitmq@workspace:packages/transport-rabbitmq"],
+
+    "@scomp/transport-websocket-browser": ["@scomp/transport-websocket-browser@workspace:packages/transport-websocket-browser"],
 
     "@scomp/transport-websocket-client": ["@scomp/transport-websocket-client@workspace:packages/transport-websocket-client"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,12 @@
         "@scomp/client": "workspace:*",
         "@scomp/core": "workspace:*",
         "@scomp/transport-rabbitmq": "workspace:*",
+        "@scomp/transport-websocket-browser": "workspace:*",
+        "@scomp/transport-websocket-server": "workspace:*",
         "@scomp/types": "workspace:*",
+      },
+      "devDependencies": {
+        "ws": "^8.18.3",
       },
     },
     "packages/client": {
@@ -116,6 +121,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@scomp/core": "workspace:*",
+        "@scomp/transport-websocket-browser": "workspace:*",
         "@scomp/transport-websocket-client": "workspace:*",
         "@scomp/types": "workspace:*",
         "@types/ws": "^8.18.1",

--- a/docs/migration-browser-transport-parity.md
+++ b/docs/migration-browser-transport-parity.md
@@ -1,0 +1,30 @@
+# Migration: browser transport parity
+
+This guide captures behavior that is now aligned across transports when using `@scomp/transport-websocket-browser`.
+
+## Who should migrate
+
+Use this guidance if your browser client already uses SCOMP WebSocket transport and you want predictable parity with Node WebSocket and RabbitMQ transports.
+
+## What is now consistent
+
+- Invocation options are carried on `request`, `signal`, `feed_start`, and `feed_stop` envelopes.
+- Priority-related hints (`priority`, `priorityClass`, `deadlineAtMs`, `targetLatencyMs`) are serialized into `meta`.
+- Metadata precedence is deterministic:
+  1. transport `config.meta`
+  2. per-call `meta`
+  3. per-call priority hints
+  4. principal-derived metadata from security hooks
+
+## Recommended migration steps
+
+1. Ensure browser clients depend on `@scomp/transport-websocket-browser`.
+2. Update client call sites to pass invocation options where needed.
+3. If using browser-side security hooks, treat them as client policy checks only.
+4. Keep authoritative authN/authZ checks on the server transport.
+
+## Caveats
+
+- Browser-side `authenticate`/`authorize` hooks can improve consistency but do not create a trust boundary.
+- `meta.auth` is intentionally opaque and must be validated server-side.
+- Priority hints are advisory metadata unless your transport/policy layer enforces scheduling.

--- a/docs/transport-json-protocol.md
+++ b/docs/transport-json-protocol.md
@@ -7,6 +7,8 @@ The same logical schema is used for both RabbitMQ and WebSocket transports.
 - RabbitMQ: JSON is carried in AMQP message bodies.
 - WebSocket: JSON is carried in text frames.
 
+Browser clients should use `@scomp/transport-websocket-browser`, which follows the same envelope schema as RabbitMQ and Node WebSocket transports.
+
 ## Core Envelope Types
 
 ### Request Envelope (Client -> Server)
@@ -28,6 +30,12 @@ Fields:
 - payload: Operation input payload.
 - meta (optional): Transport metadata for cross-cutting concerns.
 
+Metadata may include invocation and policy hints:
+
+- `traceId`, `tenantId`, `tags`
+- `auth` (opaque auth context)
+- `priority`, `priorityClass`, `deadlineAtMs`, `targetLatencyMs`
+
 Reserved route namespace:
 
 - `__scomp.*` is reserved for SCOMP control-plane request routes and MUST NOT be used by application routes.
@@ -48,6 +56,8 @@ Example metadata:
 
 The `meta.auth` field is intentionally opaque so each deployment can choose credential format
 (for example JWT, API key, signed session blob, or mTLS-derived claims).
+
+Priority hints are advisory unless enforced by a transport scheduler or policy layer.
 
 ### Response Envelope (Server -> Client)
 
@@ -135,6 +145,7 @@ Stream error:
 
 - Leaves a feed stream.
 - Client sends request envelope with op=feed_stop and payload/hash metadata.
+- Browser transport parity guarantee: `feed_stop` uses the same invocation metadata shape as `feed_start` for the originating call context.
 
 ## Control-Plane Routes (`__scomp.*`)
 
@@ -276,6 +287,12 @@ The WebSocket transport should use the same envelopes:
 
 No schema changes are needed between RabbitMQ and WebSocket transports; only framing and routing differ.
 
+### Browser WebSocket mapping
+
+- Browser/runtime clients use `@scomp/transport-websocket-browser`.
+- `request`, `signal`, `feed_start`, and `feed_stop` propagate invocation metadata and priority hints in `meta`.
+- Optional browser-side authenticate/authorize hooks run before outbound frames are sent.
+
 ## Pluggable Serialization
 
 SCOMP supports pluggable serializers by interface:
@@ -302,3 +319,8 @@ Recommended policy order:
 2. `authorize({ ...context, principal })`
 
 If no policy is configured, transports default to allow behavior for backward compatibility.
+
+### Security caveats
+
+- Browser-side security hooks are a client policy layer, not a server trust boundary.
+- Always enforce final authentication/authorization on the receiving server transport.

--- a/packages/transport-rabbitmq/test/cross-runtime-conformance.spec.ts
+++ b/packages/transport-rabbitmq/test/cross-runtime-conformance.spec.ts
@@ -1,0 +1,688 @@
+import assert from "node:assert/strict";
+import { RabbitMQTransport } from "../src";
+import { WebSocketClientTransport } from "../../transport-websocket-client/src";
+import { WebSocketBrowserTransport } from "../../transport-websocket-browser/src";
+
+const mockConnect = jest.fn();
+const mockRandomUUID = jest.fn();
+
+jest.mock("node:crypto", () => {
+  const actual = jest.requireActual("node:crypto");
+  return {
+    ...actual,
+    randomUUID: (...args: Array<unknown>) => mockRandomUUID(...args),
+  };
+});
+
+jest.mock("amqplib", () => ({
+  __esModule: true,
+  default: {
+    connect: (...args: Array<unknown>) => mockConnect(...args),
+  },
+  connect: (...args: Array<unknown>) => mockConnect(...args),
+}));
+
+type QueueConsumer = (message: unknown) => void | Promise<void>;
+
+interface TestMessageOverride {
+  properties?: {
+    correlationId?: string;
+    replyTo?: string;
+  };
+}
+
+function createMessage(payload: unknown, overrides: TestMessageOverride = {}) {
+  return {
+    content: Buffer.from(JSON.stringify(payload)),
+    properties: {
+      correlationId: overrides.properties?.correlationId ?? "corr-default",
+      replyTo: overrides.properties?.replyTo ?? "reply-queue",
+    },
+  };
+}
+
+function createFakeChannel() {
+  const queueConsumers = new Map<string, QueueConsumer>();
+  let generatedQueueCounter = 0;
+
+  const channel = {
+    writable: true,
+    prefetch: jest.fn().mockResolvedValue(undefined),
+    assertExchange: jest.fn().mockResolvedValue(undefined),
+    assertQueue: jest.fn(async (name: string) => {
+      if (name) {
+        return { queue: name };
+      }
+
+      generatedQueueCounter += 1;
+      return { queue: `generated-${generatedQueueCounter}` };
+    }),
+    bindQueue: jest.fn().mockResolvedValue(undefined),
+    unbindQueue: jest.fn().mockResolvedValue(undefined),
+    deleteQueue: jest.fn().mockResolvedValue(undefined),
+    consume: jest.fn(async (queue: string, handler: QueueConsumer) => {
+      queueConsumers.set(queue, handler);
+      return { consumerTag: `consumer-${queue}` };
+    }),
+    cancel: jest.fn().mockResolvedValue(undefined),
+    sendToQueue: jest.fn(),
+    publish: jest.fn(),
+    ack: jest.fn(),
+    on: jest.fn(),
+  };
+
+  const connection = {
+    createChannel: jest.fn().mockResolvedValue(channel),
+    on: jest.fn(),
+  };
+
+  return {
+    channel,
+    connection,
+    queueConsumers,
+  };
+}
+
+class FakeBrowserSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+
+  public readyState = FakeBrowserSocket.CONNECTING;
+  private readonly listeners = new Map<string, Array<(event: any) => void>>();
+  private readonly sent: Array<string>;
+
+  constructor(sent: Array<string>) {
+    this.sent = sent;
+    queueMicrotask(() => {
+      this.readyState = FakeBrowserSocket.OPEN;
+      this.emit("open", {});
+    });
+  }
+
+  addEventListener(type: string, listener: (event: any) => void): void {
+    const queue = this.listeners.get(type) ?? [];
+    queue.push(listener);
+    this.listeners.set(type, queue);
+  }
+
+  removeEventListener(type: string, listener: (event: any) => void): void {
+    const queue = this.listeners.get(type) ?? [];
+    this.listeners.set(
+      type,
+      queue.filter((entry) => entry !== listener),
+    );
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.emit("close", {});
+  }
+
+  emit(type: string, event: any): void {
+    const queue = this.listeners.get(type) ?? [];
+    for (const listener of queue) {
+      listener(event);
+    }
+  }
+}
+
+function createPatchedWebSocketClient() {
+  const client = new WebSocketClientTransport({
+    url: "ws://placeholder",
+    security: {
+      authenticate: () => ({
+        subject: "subject:runtime",
+        tenantId: "tenant-runtime",
+        claims: { role: "tester" },
+      }),
+    },
+  });
+  const sentPayloads: Array<string> = [];
+
+  (
+    client as unknown as {
+      getSocket: () => Promise<{ send: (payload: string) => void }>;
+    }
+  ).getSocket = async () => ({
+    send: (payload: string) => {
+      sentPayloads.push(payload);
+    },
+  });
+
+  return { client, sentPayloads };
+}
+
+function createPatchedBrowserClient() {
+  const sentPayloads: Array<string> = [];
+  let socket: FakeBrowserSocket | undefined;
+
+  const webSocketCtor = class {
+    constructor(_url: string, _protocols?: string | Array<string>) {
+      socket = new FakeBrowserSocket(sentPayloads);
+      return socket;
+    }
+  } as unknown as new (
+    url: string,
+    protocols?: string | Array<string>,
+  ) => WebSocket;
+
+  const client = new WebSocketBrowserTransport({
+    url: "ws://placeholder",
+    security: {
+      authenticate: () => ({
+        subject: "subject:runtime",
+        tenantId: "tenant-runtime",
+        claims: { role: "tester" },
+      }),
+    },
+    webSocketCtor,
+  });
+
+  return {
+    client,
+    sentPayloads,
+    getSocket: () => {
+      if (!socket) {
+        throw new Error("Expected browser socket to exist");
+      }
+      return socket;
+    },
+  };
+}
+
+function stripId(payload: Record<string, unknown>) {
+  const clone = { ...payload };
+  delete clone.id;
+  return clone;
+}
+
+async function waitFor(predicate: () => boolean, attempts = 50): Promise<void> {
+  for (let index = 0; index < attempts; index += 1) {
+    if (predicate()) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  throw new Error("Timed out waiting for condition.");
+}
+
+describe("Cross-runtime conformance: browser websocket, node websocket, rabbitmq", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    let idCounter = 0;
+    mockRandomUUID.mockImplementation(() => {
+      idCounter += 1;
+      return `id-${idCounter}`;
+    });
+  });
+
+  it("keeps request/signal metadata, priority, and auth context aligned", async () => {
+    const rabbitFake = createFakeChannel();
+    mockConnect.mockResolvedValue(rabbitFake.connection);
+
+    const rabbit = new RabbitMQTransport({
+      url: "amqp://test",
+      security: {
+        policy: {
+          authenticate: () => ({
+            subject: "subject:runtime",
+            tenantId: "tenant-runtime",
+            claims: { role: "tester" },
+          }),
+        },
+      },
+    });
+    const node = createPatchedWebSocketClient();
+    const browser = createPatchedBrowserClient();
+
+    const invokeOptions = {
+      meta: {
+        traceId: "trace-runtime",
+        tenantId: "tenant-override",
+        tags: { source: "conformance" },
+      },
+      priority: "P0" as const,
+      priorityClass: "P1" as const,
+      deadlineAtMs: 1500,
+      targetLatencyMs: 40,
+    };
+
+    const rabbitPending = rabbit.request("users.get", { id: 10 }, invokeOptions);
+    const nodePending = node.client.request("users.get", { id: 10 }, invokeOptions);
+    const browserPending = browser.client.request(
+      "users.get",
+      { id: 10 },
+      invokeOptions,
+    );
+
+    await waitFor(() => rabbitFake.channel.sendToQueue.mock.calls.length > 0);
+    await waitFor(() => node.sentPayloads.length > 0);
+    await waitFor(() => browser.sentPayloads.length > 0);
+
+    const rabbitRequestCall = rabbitFake.channel.sendToQueue.mock.calls[0];
+    const rabbitRequest = JSON.parse(
+      Buffer.from(rabbitRequestCall[1]).toString("utf8"),
+    ) as Record<string, unknown>;
+    const nodeRequest = JSON.parse(node.sentPayloads[0]) as Record<string, unknown>;
+    const browserRequest = JSON.parse(
+      browser.sentPayloads[0],
+    ) as Record<string, unknown>;
+
+    assert.deepEqual(stripId(nodeRequest), rabbitRequest);
+    assert.deepEqual(stripId(browserRequest), rabbitRequest);
+
+    const rabbitRequestOptions = rabbitRequestCall[2] as {
+      correlationId: string;
+      replyTo: string;
+    };
+    const rabbitReplyConsumer = rabbitFake.queueConsumers.get("generated-1");
+    await rabbitReplyConsumer?.(
+      createMessage(
+        { payload: { ok: true } },
+        {
+          properties: {
+            correlationId: rabbitRequestOptions.correlationId,
+            replyTo: rabbitRequestOptions.replyTo,
+          },
+        },
+      ),
+    );
+
+    (
+      node.client as unknown as {
+        handleIncoming: (message: unknown) => void;
+      }
+    ).handleIncoming({
+      id: String(nodeRequest.id),
+      payload: { ok: true },
+    });
+
+    browser.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: String(browserRequest.id),
+        payload: { ok: true },
+      }),
+    });
+
+    assert.deepEqual(await rabbitPending, { ok: true });
+    assert.deepEqual(await nodePending, { ok: true });
+    assert.deepEqual(await browserPending, { ok: true });
+
+    await Promise.all([
+      rabbit.signal("users.notify", { id: 99 }, invokeOptions),
+      node.client.signal("users.notify", { id: 99 }, invokeOptions),
+      browser.client.signal("users.notify", { id: 99 }, invokeOptions),
+    ]);
+
+    const rabbitSignal = JSON.parse(
+      Buffer.from(rabbitFake.channel.publish.mock.calls[0][2]).toString("utf8"),
+    ) as Record<string, unknown>;
+    const nodeSignal = JSON.parse(node.sentPayloads[1]) as Record<string, unknown>;
+    const browserSignal = JSON.parse(
+      browser.sentPayloads[1],
+    ) as Record<string, unknown>;
+
+    assert.deepEqual(nodeSignal, rabbitSignal);
+    assert.deepEqual(browserSignal, rabbitSignal);
+  });
+
+  it("keeps feed_start/feed_stop metadata and lifecycle semantics aligned", async () => {
+    const rabbitFake = createFakeChannel();
+    mockConnect.mockResolvedValue(rabbitFake.connection);
+
+    const rabbit = new RabbitMQTransport({
+      url: "amqp://test",
+      security: {
+        policy: {
+          authenticate: () => ({
+            subject: "subject:runtime",
+            tenantId: "tenant-runtime",
+            claims: { role: "tester" },
+          }),
+        },
+      },
+    });
+    const node = createPatchedWebSocketClient();
+    const browser = createPatchedBrowserClient();
+
+    const invokeOptions = {
+      meta: {
+        traceId: "trace-runtime",
+        tenantId: "tenant-override",
+        tags: { source: "conformance" },
+      },
+      priority: "P2" as const,
+      priorityClass: "P3" as const,
+      deadlineAtMs: 2500,
+      targetLatencyMs: 60,
+    };
+
+    const rabbitIterator = rabbit
+      .feed("users.live", { room: "alpha" }, invokeOptions)
+      [Symbol.asyncIterator]();
+    const nodeIterator = node.client
+      .feed("users.live", { room: "alpha" }, invokeOptions)
+      [Symbol.asyncIterator]();
+    const browserIterator = browser.client
+      .feed("users.live", { room: "alpha" }, invokeOptions)
+      [Symbol.asyncIterator]();
+
+    const rabbitNext = rabbitIterator.next();
+    const nodeNext = nodeIterator.next();
+    const browserNext = browserIterator.next();
+
+    await waitFor(() => rabbitFake.channel.sendToQueue.mock.calls.length > 0);
+    await waitFor(() => node.sentPayloads.length > 0);
+    await waitFor(() => browser.sentPayloads.length > 0);
+
+    const rabbitFeedStartCall = rabbitFake.channel.sendToQueue.mock.calls[0];
+    const rabbitFeedStart = JSON.parse(
+      Buffer.from(rabbitFeedStartCall[1]).toString("utf8"),
+    ) as Record<string, unknown>;
+    const nodeFeedStart = JSON.parse(node.sentPayloads[0]) as Record<string, unknown>;
+    const browserFeedStart = JSON.parse(
+      browser.sentPayloads[0],
+    ) as Record<string, unknown>;
+
+    assert.deepEqual(stripId(nodeFeedStart), rabbitFeedStart);
+    assert.deepEqual(stripId(browserFeedStart), rabbitFeedStart);
+
+    const rabbitFeedStartOptions = rabbitFeedStartCall[2] as {
+      correlationId: string;
+      replyTo: string;
+    };
+    const rabbitReplyConsumer = rabbitFake.queueConsumers.get("generated-1");
+    const feedHash = "feed-runtime";
+    const feedExchange = `scomp.live.${feedHash}`;
+
+    await rabbitReplyConsumer?.(
+      createMessage(
+        {
+          payload: {
+            exchange: feedExchange,
+            hash: feedHash,
+          },
+        },
+        {
+          properties: {
+            correlationId: rabbitFeedStartOptions.correlationId,
+            replyTo: rabbitFeedStartOptions.replyTo,
+          },
+        },
+      ),
+    );
+
+    (
+      node.client as unknown as {
+        handleIncoming: (message: unknown) => void;
+      }
+    ).handleIncoming({
+      id: String(nodeFeedStart.id),
+      payload: { exchange: feedExchange, hash: feedHash },
+    });
+
+    browser.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: String(browserFeedStart.id),
+        payload: { exchange: feedExchange, hash: feedHash },
+      }),
+    });
+
+    await waitFor(() => rabbitFake.queueConsumers.has("generated-2"));
+    const rabbitFeedConsumer = rabbitFake.queueConsumers.get("generated-2");
+
+    await rabbitFeedConsumer?.(
+      createMessage({
+        channel: "feed",
+        hash: feedHash,
+        type: "next",
+        payload: { seq: 1 },
+      }),
+    );
+    (
+      node.client as unknown as {
+        handleIncoming: (message: unknown) => void;
+      }
+    ).handleIncoming({
+      channel: "feed",
+      hash: feedHash,
+      type: "next",
+      payload: { seq: 1 },
+    });
+    browser.getSocket().emit("message", {
+      data: JSON.stringify({
+        channel: "feed",
+        hash: feedHash,
+        type: "next",
+        payload: { seq: 1 },
+      }),
+    });
+
+    const [rabbitFirst, nodeFirst, browserFirst] = await Promise.all([
+      rabbitNext,
+      nodeNext,
+      browserNext,
+    ]);
+    assert.equal(rabbitFirst.done, false);
+    assert.equal(nodeFirst.done, false);
+    assert.equal(browserFirst.done, false);
+    assert.deepEqual(rabbitFirst.value, { seq: 1 });
+    assert.deepEqual(nodeFirst.value, { seq: 1 });
+    assert.deepEqual(browserFirst.value, { seq: 1 });
+
+    const rabbitReturn = rabbitIterator.return?.(undefined);
+    const nodeReturn = nodeIterator.return?.(undefined);
+    const browserReturn = browserIterator.return?.(undefined);
+
+    if (!rabbitReturn || !nodeReturn || !browserReturn) {
+      throw new Error("Feed iterators must support return().");
+    }
+
+    await waitFor(() => rabbitFake.channel.sendToQueue.mock.calls.length > 1);
+    await waitFor(() => node.sentPayloads.length > 1);
+    await waitFor(() => browser.sentPayloads.length > 1);
+
+    const rabbitFeedStopCall = rabbitFake.channel.sendToQueue.mock.calls[1];
+    const rabbitFeedStop = JSON.parse(
+      Buffer.from(rabbitFeedStopCall[1]).toString("utf8"),
+    ) as Record<string, unknown>;
+    const nodeFeedStop = JSON.parse(node.sentPayloads[1]) as Record<string, unknown>;
+    const browserFeedStop = JSON.parse(
+      browser.sentPayloads[1],
+    ) as Record<string, unknown>;
+
+    assert.deepEqual(stripId(nodeFeedStop), rabbitFeedStop);
+    assert.deepEqual(stripId(browserFeedStop), rabbitFeedStop);
+    assert.deepEqual((nodeFeedStop as { meta?: unknown }).meta, (nodeFeedStart as { meta?: unknown }).meta);
+    assert.deepEqual((browserFeedStop as { meta?: unknown }).meta, (browserFeedStart as { meta?: unknown }).meta);
+
+    const rabbitFeedStopOptions = rabbitFeedStopCall[2] as {
+      correlationId: string;
+      replyTo: string;
+    };
+    await rabbitReplyConsumer?.(
+      createMessage(
+        { payload: { ok: true } },
+        {
+          properties: {
+            correlationId: rabbitFeedStopOptions.correlationId,
+            replyTo: rabbitFeedStopOptions.replyTo,
+          },
+        },
+      ),
+    );
+
+    (
+      node.client as unknown as {
+        handleIncoming: (message: unknown) => void;
+      }
+    ).handleIncoming({
+      id: String(nodeFeedStop.id),
+      payload: { ok: true },
+    });
+
+    browser.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: String(browserFeedStop.id),
+        payload: { ok: true },
+      }),
+    });
+
+    const [rabbitStopped, nodeStopped, browserStopped] = await Promise.all([
+      rabbitReturn,
+      nodeReturn,
+      browserReturn,
+    ]);
+
+    assert.equal(rabbitStopped.done, true);
+    assert.equal(nodeStopped.done, true);
+    assert.equal(browserStopped.done, true);
+  });
+
+  it("propagates feed error chunks as rejections across all runtimes", async () => {
+    const rabbitFake = createFakeChannel();
+    mockConnect.mockResolvedValue(rabbitFake.connection);
+
+    const rabbit = new RabbitMQTransport({ url: "amqp://test" });
+    const node = createPatchedWebSocketClient();
+    const browser = createPatchedBrowserClient();
+
+    const rabbitIterator = rabbit.feed("users.live", { room: "alpha" })[
+      Symbol.asyncIterator
+    ]();
+    const nodeIterator = node.client.feed("users.live", { room: "alpha" })[
+      Symbol.asyncIterator
+    ]();
+    const browserIterator = browser.client.feed("users.live", { room: "alpha" })[
+      Symbol.asyncIterator
+    ]();
+
+    const rabbitNext = rabbitIterator.next();
+    const nodeNext = nodeIterator.next();
+    const browserNext = browserIterator.next();
+
+    await waitFor(() => rabbitFake.channel.sendToQueue.mock.calls.length > 0);
+    await waitFor(() => node.sentPayloads.length > 0);
+    await waitFor(() => browser.sentPayloads.length > 0);
+
+    const rabbitFeedStartCall = rabbitFake.channel.sendToQueue.mock.calls[0];
+    const rabbitFeedStartOptions = rabbitFeedStartCall[2] as {
+      correlationId: string;
+      replyTo: string;
+    };
+    const nodeFeedStart = JSON.parse(node.sentPayloads[0]) as { id: string };
+    const browserFeedStart = JSON.parse(browser.sentPayloads[0]) as { id: string };
+
+    const rabbitReplyConsumer = rabbitFake.queueConsumers.get("generated-1");
+    const feedHash = "feed-error-runtime";
+    const feedExchange = `scomp.live.${feedHash}`;
+
+    await rabbitReplyConsumer?.(
+      createMessage(
+        {
+          payload: {
+            exchange: feedExchange,
+            hash: feedHash,
+          },
+        },
+        {
+          properties: {
+            correlationId: rabbitFeedStartOptions.correlationId,
+            replyTo: rabbitFeedStartOptions.replyTo,
+          },
+        },
+      ),
+    );
+    (
+      node.client as unknown as {
+        handleIncoming: (message: unknown) => void;
+      }
+    ).handleIncoming({
+      id: nodeFeedStart.id,
+      payload: { exchange: feedExchange, hash: feedHash },
+    });
+    browser.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: browserFeedStart.id,
+        payload: { exchange: feedExchange, hash: feedHash },
+      }),
+    });
+
+    await waitFor(() => rabbitFake.queueConsumers.has("generated-2"));
+    const rabbitFeedConsumer = rabbitFake.queueConsumers.get("generated-2");
+    await rabbitFeedConsumer?.(
+      createMessage({
+        channel: "feed",
+        hash: feedHash,
+        type: "error",
+        message: "runtime feed failure",
+      }),
+    );
+    (
+      node.client as unknown as {
+        handleIncoming: (message: unknown) => void;
+      }
+    ).handleIncoming({
+      channel: "feed",
+      hash: feedHash,
+      type: "error",
+      message: "runtime feed failure",
+    });
+    browser.getSocket().emit("message", {
+      data: JSON.stringify({
+        channel: "feed",
+        hash: feedHash,
+        type: "error",
+        message: "runtime feed failure",
+      }),
+    });
+
+    await waitFor(() => rabbitFake.channel.sendToQueue.mock.calls.length > 1);
+    await waitFor(() => node.sentPayloads.length > 1);
+    await waitFor(() => browser.sentPayloads.length > 1);
+
+    const rabbitFeedStopCall = rabbitFake.channel.sendToQueue.mock.calls[1];
+    const rabbitFeedStopOptions = rabbitFeedStopCall[2] as {
+      correlationId: string;
+      replyTo: string;
+    };
+    const nodeFeedStop = JSON.parse(node.sentPayloads[1]) as { id: string };
+    const browserFeedStop = JSON.parse(browser.sentPayloads[1]) as { id: string };
+
+    await rabbitReplyConsumer?.(
+      createMessage(
+        { payload: { ok: true } },
+        {
+          properties: {
+            correlationId: rabbitFeedStopOptions.correlationId,
+            replyTo: rabbitFeedStopOptions.replyTo,
+          },
+        },
+      ),
+    );
+    (
+      node.client as unknown as {
+        handleIncoming: (message: unknown) => void;
+      }
+    ).handleIncoming({
+      id: nodeFeedStop.id,
+      payload: { ok: true },
+    });
+    browser.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: browserFeedStop.id,
+        payload: { ok: true },
+      }),
+    });
+
+    await assert.rejects(() => rabbitNext, /runtime feed failure/);
+    await assert.rejects(() => nodeNext, /runtime feed failure/);
+    await assert.rejects(() => browserNext, /runtime feed failure/);
+  });
+});

--- a/packages/transport-websocket-browser/jest.config.cjs
+++ b/packages/transport-websocket-browser/jest.config.cjs
@@ -5,9 +5,5 @@ module.exports = createJestConfig({
   moduleNameMapper: {
     "^@scomp/core$": "<rootDir>/../core/src",
     "^@scomp/types$": "<rootDir>/../types/src",
-    "^@scomp/transport-websocket-browser$":
-      "<rootDir>/../transport-websocket-browser/src",
-    "^@scomp/transport-websocket-client$":
-      "<rootDir>/../transport-websocket-client/src",
   },
 });

--- a/packages/transport-websocket-browser/package.json
+++ b/packages/transport-websocket-browser/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@scomp/transport-websocket-browser",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "lint": "echo \"No lint configured for @scomp/transport-websocket-browser\"",
+    "test": "jest --config jest.config.cjs"
+  },
+  "dependencies": {
+    "@scomp/core": "workspace:*",
+    "@scomp/types": "workspace:*"
+  }
+}

--- a/packages/transport-websocket-browser/src/index.ts
+++ b/packages/transport-websocket-browser/src/index.ts
@@ -27,6 +27,19 @@ interface FeedState {
   queue: Array<unknown | Promise<never>>;
   waiters: Array<() => void>;
   closed: boolean;
+  terminalError?: Error;
+}
+
+function toDisconnectError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  const message =
+    typeof error === "string" && error.length > 0
+      ? error
+      : "WebSocket connection closed.";
+  return new SocketDisconnectedError(message);
 }
 
 type BrowserSocket = Pick<
@@ -130,6 +143,7 @@ export class WebSocketBrowserTransport implements ITransport {
   private readonly config: WebSocketBrowserTransportConfig;
   private socket?: BrowserSocket;
   private openingPromise?: Promise<BrowserSocket>;
+  private lastDisconnectError?: Error;
   private readonly pendingRequests = new Map<string, PendingRequest>();
   private readonly feeds = new Map<string, FeedState>();
   private readonly pendingFeedChunks = new Map<
@@ -212,9 +226,19 @@ export class WebSocketBrowserTransport implements ITransport {
           queue: [],
           waiters: [],
           closed: false,
+          terminalError: undefined,
         };
 
         self.feeds.set(feedHash, state);
+        if (!self.socket || !self.isOpen(self.socket)) {
+          state.closed = true;
+          state.queue.push(
+            Promise.reject(
+              self.lastDisconnectError ?? new SocketDisconnectedError(),
+            ),
+          );
+        }
+
         self.drainPendingFeedChunks(feedHash, state);
 
         try {
@@ -226,6 +250,11 @@ export class WebSocketBrowserTransport implements ITransport {
               }
 
               if (state.closed && value === undefined) {
+                const terminalError =
+                  state.terminalError ?? self.lastDisconnectError;
+                if (terminalError) {
+                  throw terminalError;
+                }
                 return;
               }
 
@@ -233,6 +262,11 @@ export class WebSocketBrowserTransport implements ITransport {
                 yield value;
               }
             } else if (state.closed) {
+              const terminalError =
+                state.terminalError ?? self.lastDisconnectError;
+              if (terminalError) {
+                throw terminalError;
+              }
               return;
             } else {
               await new Promise<void>((resolve) => state.waiters.push(resolve));
@@ -240,7 +274,19 @@ export class WebSocketBrowserTransport implements ITransport {
           }
         } finally {
           self.feeds.delete(feedHash);
-          await self.sendRpc(route, "feed_stop", { hash: feedHash }, options);
+          self.pendingFeedChunks.delete(feedHash);
+          const activeSocket = self.socket;
+          if (!activeSocket || !self.isOpen(activeSocket)) {
+            return;
+          }
+
+          try {
+            await self.sendRpc(route, "feed_stop", { hash: feedHash }, options);
+          } catch (error) {
+            if (!(error instanceof SocketDisconnectedError)) {
+              throw error;
+            }
+          }
         }
       },
     };
@@ -282,6 +328,7 @@ export class WebSocketBrowserTransport implements ITransport {
       const onOpen = () => {
         cleanup();
         this.socket = socket;
+        this.lastDisconnectError = undefined;
         this.attachSocketHandlers(socket);
         this.openingPromise = undefined;
         resolve(socket);
@@ -370,23 +417,24 @@ export class WebSocketBrowserTransport implements ITransport {
 
   private handleDisconnect(error: unknown): void {
     this.socket = undefined;
+    const disconnectError = toDisconnectError(error);
+    this.lastDisconnectError = disconnectError;
 
     for (const pending of this.pendingRequests.values()) {
-      pending.reject(error);
+      pending.reject(disconnectError);
     }
     this.pendingRequests.clear();
 
+    this.pendingFeedChunks.clear();
+
     for (const feed of this.feeds.values()) {
       feed.closed = true;
-      feed.queue.push(
-        Promise.reject(
-          error instanceof Error
-            ? error
-            : new SocketDisconnectedError(String(error)),
-        ),
-      );
-      const waiter = feed.waiters.shift();
-      waiter?.();
+      feed.terminalError = disconnectError;
+      feed.queue.push(Promise.reject(disconnectError));
+      while (feed.waiters.length > 0) {
+        const waiter = feed.waiters.shift();
+        waiter?.();
+      }
     }
   }
 
@@ -445,11 +493,12 @@ export class WebSocketBrowserTransport implements ITransport {
   private enqueueFeedChunk(feed: FeedState, message: ScompFeedChunkEnvelope): void {
     if (message.type === "done") {
       feed.closed = true;
+      feed.terminalError = undefined;
     } else if (message.type === "error") {
       feed.closed = true;
-      feed.queue.push(
-        Promise.reject(new Error(String(message.message ?? "Feed error"))),
-      );
+      const error = new Error(String(message.message ?? "Feed error"));
+      feed.terminalError = error;
+      feed.queue.push(Promise.reject(error));
     } else {
       feed.queue.push(message.payload);
     }

--- a/packages/transport-websocket-browser/src/index.ts
+++ b/packages/transport-websocket-browser/src/index.ts
@@ -176,11 +176,14 @@ export class WebSocketBrowserTransport implements ITransport {
     if (!allowed) {
       throw new Error(`signal not authorized for route: ${route}`);
     }
+
+    const outboundMeta = await this.composeOutboundMeta(options, principal);
+
     this.sendJson(socket, {
       route,
       op: "signal",
       payload,
-      meta: this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal)),
+      meta: outboundMeta,
     });
   }
 
@@ -414,12 +417,14 @@ export class WebSocketBrowserTransport implements ITransport {
       this.pendingRequests.set(id, { resolve, reject });
     });
 
+    const outboundMeta = await this.composeOutboundMeta(options, principal);
+
     this.sendJson(socket, {
       id,
       route,
       op,
       payload,
-      meta: this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal)),
+      meta: outboundMeta,
     } satisfies ScompTransportRequestEnvelope);
 
     return response;
@@ -490,6 +495,20 @@ export class WebSocketBrowserTransport implements ITransport {
       },
       tenantId: principal.tenantId,
     };
+  }
+
+  /**
+   * Deterministic outbound meta precedence (Node client parity):
+   * config.meta -> options.meta -> priority hints -> principal-derived auth context.
+   */
+  private async composeOutboundMeta(
+    options: ScompClientInvokeOptions | undefined,
+    principal: ScompTransportPrincipal | undefined,
+  ): Promise<ScompTransportMessageMeta | undefined> {
+    const priorityMeta = toPriorityMeta(options);
+    const baseMeta = this.mergeMeta(await this.resolveMeta(), options?.meta);
+    const effectiveMeta = this.mergeMeta(baseMeta, priorityMeta);
+    return this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal));
   }
 
   private mergeMeta(

--- a/packages/transport-websocket-browser/src/index.ts
+++ b/packages/transport-websocket-browser/src/index.ts
@@ -1,0 +1,540 @@
+import { randomUUID } from "node:crypto";
+import type { ITransport, ScompClientInvokeOptions } from "@scomp/core";
+import type {
+  ScompFeedChunkEnvelope,
+  ScompTransportMessageMeta,
+  ScompTransportOperation,
+  ScompTransportPrincipal,
+  ScompTransportSecurityContext,
+  ScompTransportSecurityPolicy,
+  ScompTransportRequestEnvelope,
+  ScompTransportResponseEnvelope,
+} from "@scomp/types";
+
+export class SocketDisconnectedError extends Error {
+  constructor(message = "WebSocket connection closed.") {
+    super(message);
+    this.name = "SocketDisconnectedError";
+  }
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+}
+
+interface FeedState {
+  queue: Array<unknown | Promise<never>>;
+  waiters: Array<() => void>;
+  closed: boolean;
+}
+
+type BrowserSocket = Pick<
+  WebSocket,
+  | "send"
+  | "close"
+  | "addEventListener"
+  | "removeEventListener"
+  | "readyState"
+>;
+
+type BrowserWebSocketCtor = new (
+  url: string,
+  protocols?: string | Array<string>,
+) => BrowserSocket;
+
+type TransportMessage =
+  | ScompTransportRequestEnvelope
+  | ScompTransportResponseEnvelope
+  | ScompFeedChunkEnvelope;
+
+export interface WebSocketBrowserTransportConfig {
+  url: string;
+  protocols?: string | Array<string>;
+  meta?:
+    | ScompTransportMessageMeta
+    | (() => ScompTransportMessageMeta | Promise<ScompTransportMessageMeta>);
+  security?: ScompTransportSecurityPolicy;
+  webSocketCtor?: BrowserWebSocketCtor;
+}
+
+function toPriorityMeta(
+  options?: ScompClientInvokeOptions,
+): ScompTransportMessageMeta | undefined {
+  if (!options) {
+    return undefined;
+  }
+
+  const { priority, priorityClass, deadlineAtMs, targetLatencyMs } = options;
+  if (
+    priority === undefined &&
+    priorityClass === undefined &&
+    deadlineAtMs === undefined &&
+    targetLatencyMs === undefined
+  ) {
+    return undefined;
+  }
+
+  const meta: ScompTransportMessageMeta = {};
+  if (priority !== undefined) {
+    meta.priority = priority;
+  }
+  if (priorityClass !== undefined) {
+    meta.priorityClass = priorityClass;
+  }
+  if (deadlineAtMs !== undefined) {
+    meta.deadlineAtMs = deadlineAtMs;
+  }
+  if (targetLatencyMs !== undefined) {
+    meta.targetLatencyMs = targetLatencyMs;
+  }
+
+  return meta;
+}
+
+function safeJsonParse(text: string): any {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return {};
+  }
+}
+
+function isFeedChunkEnvelope(
+  message: TransportMessage,
+): message is ScompFeedChunkEnvelope {
+  return (message as ScompFeedChunkEnvelope).channel === "feed";
+}
+
+async function toText(data: unknown): Promise<string> {
+  if (typeof data === "string") {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data);
+  }
+
+  if (typeof Blob !== "undefined" && data instanceof Blob) {
+    return data.text();
+  }
+
+  return String(data ?? "");
+}
+
+export class WebSocketBrowserTransport implements ITransport {
+  private readonly config: WebSocketBrowserTransportConfig;
+  private socket?: BrowserSocket;
+  private openingPromise?: Promise<BrowserSocket>;
+  private readonly pendingRequests = new Map<string, PendingRequest>();
+  private readonly feeds = new Map<string, FeedState>();
+  private readonly pendingFeedChunks = new Map<
+    string,
+    Array<ScompFeedChunkEnvelope>
+  >();
+
+  constructor(config: WebSocketBrowserTransportConfig) {
+    this.config = config;
+  }
+
+  async listen(_router: Record<string, unknown>): Promise<void> {
+    throw new Error(
+      "WebSocketBrowserTransport.listen() is not supported. Use WebSocketServerTransport to host routes.",
+    );
+  }
+
+  async request(
+    route: string,
+    payload: any,
+    options?: ScompClientInvokeOptions,
+  ): Promise<any> {
+    return this.sendRpc(route, "request", payload, options);
+  }
+
+  async signal(
+    route: string,
+    payload: any,
+    options?: ScompClientInvokeOptions,
+  ): Promise<void> {
+    const socket = await this.getSocket();
+    const operation: ScompTransportOperation = "signal";
+    const priorityMeta = toPriorityMeta(options);
+    const baseMeta = this.mergeMeta(await this.resolveMeta(), options?.meta);
+    const effectiveMeta = this.mergeMeta(baseMeta, priorityMeta);
+    const { allowed, principal } = await this.checkSecurity({
+      direction: "outbound",
+      transport: "websocket",
+      route,
+      operation,
+      payload,
+      meta: effectiveMeta,
+    });
+    if (!allowed) {
+      throw new Error(`signal not authorized for route: ${route}`);
+    }
+    this.sendJson(socket, {
+      route,
+      op: "signal",
+      payload,
+      meta: this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal)),
+    });
+  }
+
+  feed(
+    route: string,
+    payload: any,
+    options?: ScompClientInvokeOptions,
+  ): AsyncIterable<any> {
+    const self = this;
+
+    return {
+      async *[Symbol.asyncIterator]() {
+        const handshake = await self.sendRpc(
+          route,
+          "feed_start",
+          payload,
+          options,
+        );
+        const feedHash = String(handshake?.hash ?? "");
+
+        if (!feedHash) {
+          throw new Error("Feed start response did not include a hash.");
+        }
+
+        const state: FeedState = {
+          queue: [],
+          waiters: [],
+          closed: false,
+        };
+
+        self.feeds.set(feedHash, state);
+        self.drainPendingFeedChunks(feedHash, state);
+
+        try {
+          while (true) {
+            if (state.queue.length > 0) {
+              const value = state.queue.shift();
+              if (value instanceof Promise) {
+                await value;
+              }
+
+              if (state.closed && value === undefined) {
+                return;
+              }
+
+              if (value !== undefined) {
+                yield value;
+              }
+            } else if (state.closed) {
+              return;
+            } else {
+              await new Promise<void>((resolve) => state.waiters.push(resolve));
+            }
+          }
+        } finally {
+          self.feeds.delete(feedHash);
+          await self.sendRpc(route, "feed_stop", { hash: feedHash }, options);
+        }
+      },
+    };
+  }
+
+  private resolveWebSocketCtor(): BrowserWebSocketCtor {
+    if (this.config.webSocketCtor) {
+      return this.config.webSocketCtor;
+    }
+
+    if (typeof globalThis.WebSocket !== "function") {
+      throw new Error(
+        "No WebSocket constructor found. Provide config.webSocketCtor in non-browser environments.",
+      );
+    }
+
+    return globalThis.WebSocket as unknown as BrowserWebSocketCtor;
+  }
+
+  private isOpen(socket: BrowserSocket): boolean {
+    const openState =
+      typeof WebSocket !== "undefined" ? WebSocket.OPEN : 1;
+    return socket.readyState === openState;
+  }
+
+  private async getSocket(): Promise<BrowserSocket> {
+    if (this.socket && this.isOpen(this.socket)) {
+      return this.socket;
+    }
+
+    if (this.openingPromise) {
+      return this.openingPromise;
+    }
+
+    this.openingPromise = new Promise<BrowserSocket>((resolve, reject) => {
+      const WebSocketCtor = this.resolveWebSocketCtor();
+      const socket = new WebSocketCtor(this.config.url, this.config.protocols);
+
+      const onOpen = () => {
+        cleanup();
+        this.socket = socket;
+        this.attachSocketHandlers(socket);
+        this.openingPromise = undefined;
+        resolve(socket);
+      };
+
+      const onError = (event: Event) => {
+        cleanup();
+        this.openingPromise = undefined;
+        reject(event);
+      };
+
+      const cleanup = () => {
+        socket.removeEventListener("open", onOpen as EventListener);
+        socket.removeEventListener("error", onError as EventListener);
+      };
+
+      socket.addEventListener("open", onOpen as EventListener, { once: true });
+      socket.addEventListener("error", onError as EventListener, {
+        once: true,
+      });
+    });
+
+    return this.openingPromise;
+  }
+
+  private attachSocketHandlers(socket: BrowserSocket): void {
+    socket.addEventListener("message", (event: MessageEvent) => {
+      void (async () => {
+        const message = safeJsonParse(await toText(event.data)) as TransportMessage;
+        this.handleIncoming(message);
+      })();
+    });
+
+    socket.addEventListener("close", () => {
+      this.handleDisconnect(new SocketDisconnectedError());
+    });
+
+    socket.addEventListener("error", (event) => {
+      this.handleDisconnect(event);
+    });
+  }
+
+  private handleIncoming(message: TransportMessage): void {
+    if (isFeedChunkEnvelope(message)) {
+      const hash = String(message.hash ?? "");
+      const feed = this.feeds.get(hash);
+      if (!feed) {
+        const pending = this.pendingFeedChunks.get(hash) ?? [];
+        pending.push(message);
+        this.pendingFeedChunks.set(hash, pending);
+        return;
+      }
+
+      this.enqueueFeedChunk(feed, message);
+      return;
+    }
+
+    const id = String((message as ScompTransportResponseEnvelope).id ?? "");
+    if (!id) {
+      return;
+    }
+
+    const pending = this.pendingRequests.get(id);
+    if (!pending) {
+      return;
+    }
+
+    this.pendingRequests.delete(id);
+
+    if (
+      "error" in message &&
+      typeof message.error === "string" &&
+      message.error.length > 0
+    ) {
+      pending.reject(new Error(message.error));
+      return;
+    }
+
+    if ("payload" in message) {
+      pending.resolve(message.payload);
+      return;
+    }
+
+    pending.resolve(undefined);
+  }
+
+  private handleDisconnect(error: unknown): void {
+    this.socket = undefined;
+
+    for (const pending of this.pendingRequests.values()) {
+      pending.reject(error);
+    }
+    this.pendingRequests.clear();
+
+    for (const feed of this.feeds.values()) {
+      feed.closed = true;
+      feed.queue.push(
+        Promise.reject(
+          error instanceof Error
+            ? error
+            : new SocketDisconnectedError(String(error)),
+        ),
+      );
+      const waiter = feed.waiters.shift();
+      waiter?.();
+    }
+  }
+
+  private async sendRpc(
+    route: string,
+    op: ScompTransportOperation,
+    payload: unknown,
+    options?: ScompClientInvokeOptions,
+  ): Promise<any> {
+    const socket = await this.getSocket();
+    const priorityMeta = toPriorityMeta(options);
+    const baseMeta = this.mergeMeta(await this.resolveMeta(), options?.meta);
+    const effectiveMeta = this.mergeMeta(baseMeta, priorityMeta);
+    const { allowed, principal } = await this.checkSecurity({
+      direction: "outbound",
+      transport: "websocket",
+      route,
+      operation: op,
+      payload,
+      meta: effectiveMeta,
+    });
+    if (!allowed) {
+      throw new Error(`${op} not authorized for route: ${route}`);
+    }
+    const id = randomUUID();
+
+    const response = new Promise<unknown>((resolve, reject) => {
+      this.pendingRequests.set(id, { resolve, reject });
+    });
+
+    this.sendJson(socket, {
+      id,
+      route,
+      op,
+      payload,
+      meta: this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal)),
+    } satisfies ScompTransportRequestEnvelope);
+
+    return response;
+  }
+
+  private drainPendingFeedChunks(hash: string, feed: FeedState): void {
+    const pending = this.pendingFeedChunks.get(hash);
+    if (!pending || pending.length === 0) {
+      return;
+    }
+
+    this.pendingFeedChunks.delete(hash);
+    for (const message of pending) {
+      this.enqueueFeedChunk(feed, message);
+    }
+  }
+
+  private enqueueFeedChunk(feed: FeedState, message: ScompFeedChunkEnvelope): void {
+    if (message.type === "done") {
+      feed.closed = true;
+    } else if (message.type === "error") {
+      feed.closed = true;
+      feed.queue.push(
+        Promise.reject(new Error(String(message.message ?? "Feed error"))),
+      );
+    } else {
+      feed.queue.push(message.payload);
+    }
+
+    const waiter = feed.waiters.shift();
+    waiter?.();
+  }
+
+  private sendJson(socket: BrowserSocket, payload: unknown): void {
+    const serialized = JSON.stringify(payload);
+    socket.send(serialized);
+  }
+
+  private async resolveMeta(): Promise<ScompTransportMessageMeta | undefined> {
+    const metaConfig = this.config.meta;
+    if (!metaConfig) {
+      return undefined;
+    }
+
+    if (typeof metaConfig === "function") {
+      return metaConfig();
+    }
+
+    return metaConfig;
+  }
+
+  private toPrincipalMeta(
+    principal: ScompTransportPrincipal | undefined,
+  ): ScompTransportMessageMeta | undefined {
+    if (!principal) {
+      return undefined;
+    }
+
+    return {
+      auth: {
+        subject: principal.subject,
+        tenantId: principal.tenantId,
+        scopes: principal.scopes,
+        claims: principal.claims,
+        issuedAt: principal.issuedAt,
+        expiresAt: principal.expiresAt,
+        authType: principal.authType,
+      },
+      tenantId: principal.tenantId,
+    };
+  }
+
+  private mergeMeta(
+    baseMeta: ScompTransportMessageMeta | undefined,
+    overlayMeta: ScompTransportMessageMeta | undefined,
+  ): ScompTransportMessageMeta | undefined {
+    if (!baseMeta && !overlayMeta) {
+      return undefined;
+    }
+
+    return {
+      ...(baseMeta ?? {}),
+      ...(overlayMeta ?? {}),
+    };
+  }
+
+  private async checkSecurity(
+    ctx: Omit<ScompTransportSecurityContext, "principal">,
+  ): Promise<{ allowed: boolean; principal?: ScompTransportPrincipal }> {
+    const policy = this.config.security;
+    if (!policy) {
+      return { allowed: true };
+    }
+
+    const principal = policy.authenticate
+      ? await policy.authenticate(ctx)
+      : undefined;
+
+    if (!policy.authorize) {
+      return { allowed: true, principal: principal ?? undefined };
+    }
+
+    const allowed = Boolean(
+      await policy.authorize({
+        ...ctx,
+        principal: principal ?? undefined,
+      }),
+    );
+
+    return { allowed, principal: principal ?? undefined };
+  }
+}
+
+export function createWebSocketBrowserTransport(
+  config: WebSocketBrowserTransportConfig,
+): WebSocketBrowserTransport {
+  return new WebSocketBrowserTransport(config);
+}

--- a/packages/transport-websocket-browser/test/websocket-browser-transport.spec.ts
+++ b/packages/transport-websocket-browser/test/websocket-browser-transport.spec.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  type ScompTransportSecurityPolicy,
   type ScompTransportRequestEnvelope,
   type ScompTransportResponseEnvelope,
 } from "@scomp/types";
@@ -63,7 +64,10 @@ interface BrowserHarness {
 }
 
 function createHarness(options?: {
-  meta?: Record<string, unknown>;
+  meta?:
+    | Record<string, unknown>
+    | (() => Record<string, unknown> | Promise<Record<string, unknown>>);
+  security?: ScompTransportSecurityPolicy;
 }): BrowserHarness {
   const sent: Array<string> = [];
   let socket: FakeWebSocket | undefined;
@@ -81,6 +85,7 @@ function createHarness(options?: {
   const transport = new WebSocketBrowserTransport({
     url: "ws://example.test",
     meta: options?.meta,
+    security: options?.security,
     webSocketCtor,
   });
 
@@ -240,5 +245,124 @@ describe("WebSocketBrowserTransport invocation parity", () => {
 
     const stopResult = await pendingReturn;
     assert.equal(stopResult.done, true);
+  });
+
+  it("executes authenticate and authorize hooks for request/signal/feed operations", async () => {
+    const observedOps: Array<string> = [];
+    const observedSubjects: Array<string | undefined> = [];
+
+    const harness = createHarness({
+      meta: { traceId: "trace-security" },
+      security: {
+        authenticate: ({ operation }) => ({
+          subject: `subject:${operation}`,
+          tenantId: "tenant-principal",
+          claims: { via: "authn" },
+        }),
+        authorize: (ctx) => {
+          observedOps.push(ctx.operation);
+          observedSubjects.push(ctx.principal?.subject);
+          return true;
+        },
+      },
+    });
+
+    const requestPending = harness.transport.request("users.get", { id: 1 }, {
+      meta: {
+        tenantId: "tenant-invoke",
+        auth: { source: "invoke" },
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const requestEnvelope = parseEnvelope(harness.sent[0]);
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: requestEnvelope.id,
+        payload: { ok: true },
+      } satisfies ScompTransportResponseEnvelope),
+    });
+    await requestPending;
+
+    await harness.transport.signal("users.notify", { id: 2 }, {
+      meta: { tenantId: "tenant-signal" },
+    });
+
+    const iterator = harness.transport
+      .feed("users.live", { room: "alpha" }, {
+        meta: { tenantId: "tenant-feed" },
+      })
+      [Symbol.asyncIterator]();
+    const pendingNext = iterator.next();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const feedStartEnvelope = parseEnvelope(harness.sent[2]);
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: feedStartEnvelope.id,
+        payload: { hash: "feed-security", exchange: "scomp.live.feed-security" },
+      } satisfies ScompTransportResponseEnvelope),
+    });
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        channel: "feed",
+        hash: "feed-security",
+        type: "next",
+        payload: { seq: 1 },
+      }),
+    });
+    await pendingNext;
+
+    const pendingReturn = iterator.return?.(undefined);
+    if (!pendingReturn) {
+      throw new Error("Expected feed iterator return()");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const feedStopEnvelope = parseEnvelope(harness.sent[3]);
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: feedStopEnvelope.id,
+        payload: { ok: true },
+      } satisfies ScompTransportResponseEnvelope),
+    });
+
+    await pendingReturn;
+
+    assert.deepEqual(observedOps, [
+      "request",
+      "signal",
+      "feed_start",
+      "feed_stop",
+    ]);
+    assert.deepEqual(observedSubjects, [
+      "subject:request",
+      "subject:signal",
+      "subject:feed_start",
+      "subject:feed_stop",
+    ]);
+
+    assert.equal(requestEnvelope.meta?.tenantId, "tenant-principal");
+    assert.equal(
+      (requestEnvelope.meta?.auth as { subject?: string } | undefined)?.subject,
+      "subject:request",
+    );
+  });
+
+  it("fails denied operations before sending envelopes", async () => {
+    const harness = createHarness({
+      security: {
+        authorize: ({ operation }) => operation !== "signal",
+      },
+    });
+
+    await assert.rejects(
+      () => harness.transport.signal("users.notify", { id: 9 }),
+      /not authorized/i,
+    );
+
+    assert.equal(harness.sent.length, 0);
   });
 });

--- a/packages/transport-websocket-browser/test/websocket-browser-transport.spec.ts
+++ b/packages/transport-websocket-browser/test/websocket-browser-transport.spec.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import {
+  type ScompTransportRequestEnvelope,
+  type ScompTransportResponseEnvelope,
+} from "@scomp/types";
+import { WebSocketBrowserTransport } from "../src";
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+
+  public readyState = FakeWebSocket.CONNECTING;
+  private readonly listeners = new Map<string, Array<(event: any) => void>>();
+  private readonly sent: Array<string>;
+
+  constructor(
+    private readonly _url: string,
+    _protocols: string | Array<string> | undefined,
+    sent: Array<string>,
+  ) {
+    this.sent = sent;
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.emit("open", {});
+    });
+  }
+
+  addEventListener(type: string, listener: (event: any) => void): void {
+    const queue = this.listeners.get(type) ?? [];
+    queue.push(listener);
+    this.listeners.set(type, queue);
+  }
+
+  removeEventListener(type: string, listener: (event: any) => void): void {
+    const queue = this.listeners.get(type) ?? [];
+    this.listeners.set(
+      type,
+      queue.filter((entry) => entry !== listener),
+    );
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.emit("close", {});
+  }
+
+  emit(type: string, event: any): void {
+    const queue = this.listeners.get(type) ?? [];
+    for (const listener of queue) {
+      listener(event);
+    }
+  }
+}
+
+interface BrowserHarness {
+  transport: WebSocketBrowserTransport;
+  sent: Array<string>;
+  getSocket: () => FakeWebSocket;
+}
+
+function createHarness(options?: {
+  meta?: Record<string, unknown>;
+}): BrowserHarness {
+  const sent: Array<string> = [];
+  let socket: FakeWebSocket | undefined;
+
+  const webSocketCtor = class {
+    constructor(url: string, protocols?: string | Array<string>) {
+      socket = new FakeWebSocket(url, protocols, sent);
+      return socket;
+    }
+  } as unknown as new (
+    url: string,
+    protocols?: string | Array<string>,
+  ) => WebSocket;
+
+  const transport = new WebSocketBrowserTransport({
+    url: "ws://example.test",
+    meta: options?.meta,
+    webSocketCtor,
+  });
+
+  return {
+    transport,
+    sent,
+    getSocket: () => {
+      if (!socket) {
+        throw new Error("Expected socket to initialize");
+      }
+
+      return socket;
+    },
+  };
+}
+
+function parseEnvelope(payload: string): ScompTransportRequestEnvelope {
+  return JSON.parse(payload) as ScompTransportRequestEnvelope;
+}
+
+function parseResponse(payload: string): ScompTransportResponseEnvelope {
+  return JSON.parse(payload) as ScompTransportResponseEnvelope;
+}
+
+describe("WebSocketBrowserTransport invocation parity", () => {
+  it("includes invocation options in request envelope metadata", async () => {
+    const harness = createHarness({
+      meta: {
+        traceId: "trace-request",
+        tags: { source: "browser" },
+      },
+    });
+
+    const pending = harness.transport.request("users.get", { id: 1 }, {
+      meta: { tenantId: "tenant-a" },
+      priority: "P0",
+      priorityClass: "P1",
+      deadlineAtMs: 500,
+      targetLatencyMs: 20,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const outbound = parseEnvelope(harness.sent[0]);
+    assert.equal(outbound.route, "users.get");
+    assert.equal(outbound.op, "request");
+    assert.equal(outbound.meta?.traceId, "trace-request");
+    assert.equal(outbound.meta?.tenantId, "tenant-a");
+    assert.equal(outbound.meta?.priority, "P0");
+    assert.equal(outbound.meta?.priorityClass, "P1");
+    assert.equal(outbound.meta?.deadlineAtMs, 500);
+    assert.equal(outbound.meta?.targetLatencyMs, 20);
+    assert.deepEqual(outbound.meta?.tags, { source: "browser" });
+
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: outbound.id,
+        payload: { ok: true },
+      } satisfies ScompTransportResponseEnvelope),
+    });
+
+    assert.deepEqual(await pending, { ok: true });
+  });
+
+  it("includes invocation options in signal envelopes", async () => {
+    const harness = createHarness({
+      meta: {
+        traceId: "trace-signal",
+      },
+    });
+
+    await harness.transport.signal("users.notify", { id: 2 }, {
+      meta: { tenantId: "tenant-s" },
+      priority: "P2",
+      priorityClass: "P3",
+      deadlineAtMs: 1000,
+      targetLatencyMs: 50,
+    });
+
+    const outbound = parseEnvelope(harness.sent[0]);
+    assert.equal(outbound.op, "signal");
+    assert.equal(outbound.meta?.traceId, "trace-signal");
+    assert.equal(outbound.meta?.tenantId, "tenant-s");
+    assert.equal(outbound.meta?.priority, "P2");
+    assert.equal(outbound.meta?.priorityClass, "P3");
+    assert.equal(outbound.meta?.deadlineAtMs, 1000);
+    assert.equal(outbound.meta?.targetLatencyMs, 50);
+  });
+
+  it("uses identical metadata for feed_start and feed_stop", async () => {
+    const harness = createHarness({
+      meta: {
+        traceId: "trace-feed",
+      },
+    });
+
+    const iterator = harness.transport
+      .feed("users.live", { room: "alpha" }, {
+        meta: { tenantId: "tenant-f" },
+        priority: "P1",
+        priorityClass: "P2",
+        deadlineAtMs: 2500,
+        targetLatencyMs: 75,
+      })
+      [Symbol.asyncIterator]();
+
+    const pendingNext = iterator.next();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const feedStart = parseEnvelope(harness.sent[0]);
+    assert.equal(feedStart.op, "feed_start");
+    assert.equal(feedStart.meta?.traceId, "trace-feed");
+    assert.equal(feedStart.meta?.tenantId, "tenant-f");
+    assert.equal(feedStart.meta?.priority, "P1");
+    assert.equal(feedStart.meta?.priorityClass, "P2");
+    assert.equal(feedStart.meta?.deadlineAtMs, 2500);
+    assert.equal(feedStart.meta?.targetLatencyMs, 75);
+
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: feedStart.id,
+        payload: { hash: "feed-1", exchange: "scomp.live.feed-1" },
+      } satisfies ScompTransportResponseEnvelope),
+    });
+
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        channel: "feed",
+        hash: "feed-1",
+        type: "next",
+        payload: { seq: 1 },
+      }),
+    });
+
+    const first = await pendingNext;
+    assert.equal(first.done, false);
+    assert.deepEqual(first.value, { seq: 1 });
+
+    const pendingReturn = iterator.return?.(undefined);
+    if (!pendingReturn) {
+      throw new Error("Expected feed iterator return()");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const feedStop = parseEnvelope(harness.sent[1]);
+    assert.equal(feedStop.op, "feed_stop");
+    assert.deepEqual(feedStop.payload, { hash: "feed-1" });
+    assert.deepEqual(feedStop.meta, feedStart.meta);
+
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: feedStop.id,
+        payload: { ok: true },
+      } satisfies ScompTransportResponseEnvelope),
+    });
+
+    const stopResult = await pendingReturn;
+    assert.equal(stopResult.done, true);
+  });
+});

--- a/packages/transport-websocket-browser/test/websocket-browser-transport.spec.ts
+++ b/packages/transport-websocket-browser/test/websocket-browser-transport.spec.ts
@@ -4,7 +4,7 @@ import {
   type ScompTransportRequestEnvelope,
   type ScompTransportResponseEnvelope,
 } from "@scomp/types";
-import { WebSocketBrowserTransport } from "../src";
+import { SocketDisconnectedError, WebSocketBrowserTransport } from "../src";
 
 class FakeWebSocket {
   static readonly CONNECTING = 0;
@@ -364,5 +364,82 @@ describe("WebSocketBrowserTransport invocation parity", () => {
     );
 
     assert.equal(harness.sent.length, 0);
+  });
+
+  it("delivers queued feed chunks that arrive before feed_start response", async () => {
+    const harness = createHarness();
+
+    const iterator = harness.transport
+      .feed("users.live", { room: "alpha" })
+      [Symbol.asyncIterator]();
+
+    const pendingFirst = iterator.next();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const feedStart = parseEnvelope(harness.sent[0]);
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        channel: "feed",
+        hash: "feed-race",
+        type: "next",
+        payload: { seq: 1 },
+      }),
+    });
+
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: feedStart.id,
+        payload: { hash: "feed-race", exchange: "scomp.live.feed-race" },
+      } satisfies ScompTransportResponseEnvelope),
+    });
+
+    const first = await pendingFirst;
+    assert.equal(first.done, false);
+    assert.deepEqual(first.value, { seq: 1 });
+
+    const pendingStop = iterator.return?.(undefined);
+    if (!pendingStop) {
+      throw new Error("Expected feed iterator return()");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const feedStop = parseEnvelope(harness.sent[1]);
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: feedStop.id,
+        payload: { ok: true },
+      } satisfies ScompTransportResponseEnvelope),
+    });
+
+    const stopResult = await pendingStop;
+    assert.equal(stopResult.done, true);
+  });
+
+  it("propagates disconnect to pending request and active feed", async () => {
+    const harness = createHarness();
+
+    const pendingRequest = harness.transport.request("users.get", { id: 1 });
+    const iterator = harness.transport
+      .feed("users.live", { room: "alpha" })
+      [Symbol.asyncIterator]();
+
+    const pendingFeedNext = iterator.next();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const feedStart = parseEnvelope(harness.sent[1]);
+    harness.getSocket().emit("message", {
+      data: JSON.stringify({
+        id: feedStart.id,
+        payload: { hash: "feed-disconnect", exchange: "scomp.live.feed-disconnect" },
+      } satisfies ScompTransportResponseEnvelope),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    harness.getSocket().close();
+
+    await assert.rejects(pendingRequest, SocketDisconnectedError);
+    const feedResult = await pendingFeedNext;
+    assert.equal(feedResult.done, true);
   });
 });

--- a/packages/transport-websocket-browser/tsconfig.json
+++ b/packages/transport-websocket-browser/tsconfig.json
@@ -4,13 +4,12 @@
     "composite": true,
     "rootDir": "src",
     "outDir": "dist",
-    "tsBuildInfoFile": "dist/.tsbuildinfo"
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
+    "lib": ["es2019", "dom"]
   },
   "references": [
     { "path": "../core" },
-    { "path": "../types" },
-    { "path": "../transport-websocket-browser" },
-    { "path": "../transport-websocket-client" }
+    { "path": "../types" }
   ],
   "include": ["src/**/*"]
 }

--- a/packages/transport-websocket-server/package.json
+++ b/packages/transport-websocket-server/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@scomp/core": "workspace:*",
+    "@scomp/transport-websocket-browser": "workspace:*",
     "@scomp/types": "workspace:*",
     "@scomp/transport-websocket-client": "workspace:*",
     "@types/ws": "^8.18.1",

--- a/packages/transport-websocket-server/test/websocket-transport.spec.ts
+++ b/packages/transport-websocket-server/test/websocket-transport.spec.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { createServer, type Server as HttpServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { type CompiledRoute, type CompiledRouter } from "@scomp/core";
+import { WebSocketBrowserTransport } from "@scomp/transport-websocket-browser";
 import { WebSocketClientTransport } from "@scomp/transport-websocket-client";
 import { WebSocketServerTransport } from "../src";
 
@@ -95,6 +96,120 @@ async function closeClientTransport(
 }
 
 describe("WebSocket transports", () => {
+  it("passes invocation options metadata through browser outbound envelopes", async () => {
+    const observed: Array<{
+      route: string;
+      op: string;
+      meta?: Record<string, unknown>;
+    }> = [];
+
+    const router: Record<string, CompiledRoute> = {
+      "meta.request": {
+        route: "meta.request",
+        kind: "request",
+        handler: async (payload: unknown) => payload,
+      },
+      "meta.signal": {
+        route: "meta.signal",
+        kind: "signal",
+        handler: async () => undefined,
+      },
+      "meta.feed": {
+        route: "meta.feed",
+        kind: "feed",
+        strategy: "fanout",
+        handler: async function* () {
+          yield { ok: true };
+        },
+      },
+    };
+
+    const harness = await createHarness(router);
+
+    const browser = new WebSocketBrowserTransport({
+      url: harness.url,
+      meta: { traceId: "trace-browser" },
+      security: {
+        authorize: (ctx) => {
+          observed.push({
+            route: ctx.route,
+            op: ctx.operation,
+            meta: ctx.meta as Record<string, unknown> | undefined,
+          });
+          return true;
+        },
+      },
+    });
+
+    try {
+      await browser.request("meta.request", { id: 1 }, {
+        meta: { tenantId: "tenant-r" },
+        priority: "P0",
+        priorityClass: "P1",
+        deadlineAtMs: 111,
+        targetLatencyMs: 22,
+      });
+
+      await browser.signal("meta.signal", { id: 2 }, {
+        meta: { tenantId: "tenant-s" },
+        priority: "P2",
+        priorityClass: "P3",
+        deadlineAtMs: 222,
+        targetLatencyMs: 33,
+      });
+
+      const feedIterator = browser
+        .feed("meta.feed", { id: 3 }, {
+          meta: { tenantId: "tenant-f" },
+          priority: "P1",
+          priorityClass: "P2",
+          deadlineAtMs: 333,
+          targetLatencyMs: 44,
+        })
+        [Symbol.asyncIterator]();
+
+      await feedIterator.next();
+      await feedIterator.return?.(undefined);
+
+      const requestMeta = observed.find(
+        (entry) => entry.route === "meta.request" && entry.op === "request",
+      )?.meta;
+      assert.equal(requestMeta?.traceId, "trace-browser");
+      assert.equal(requestMeta?.tenantId, "tenant-r");
+      assert.equal(requestMeta?.priority, "P0");
+      assert.equal(requestMeta?.priorityClass, "P1");
+      assert.equal(requestMeta?.deadlineAtMs, 111);
+      assert.equal(requestMeta?.targetLatencyMs, 22);
+
+      const signalMeta = observed.find(
+        (entry) => entry.route === "meta.signal" && entry.op === "signal",
+      )?.meta;
+      assert.equal(signalMeta?.traceId, "trace-browser");
+      assert.equal(signalMeta?.tenantId, "tenant-s");
+      assert.equal(signalMeta?.priority, "P2");
+      assert.equal(signalMeta?.priorityClass, "P3");
+      assert.equal(signalMeta?.deadlineAtMs, 222);
+      assert.equal(signalMeta?.targetLatencyMs, 33);
+
+      const feedStartMeta = observed.find(
+        (entry) => entry.route === "meta.feed" && entry.op === "feed_start",
+      )?.meta;
+      assert.equal(feedStartMeta?.traceId, "trace-browser");
+      assert.equal(feedStartMeta?.tenantId, "tenant-f");
+      assert.equal(feedStartMeta?.priority, "P1");
+      assert.equal(feedStartMeta?.priorityClass, "P2");
+      assert.equal(feedStartMeta?.deadlineAtMs, 333);
+      assert.equal(feedStartMeta?.targetLatencyMs, 44);
+
+      const feedStopMeta = observed.find(
+        (entry) => entry.route === "meta.feed" && entry.op === "feed_stop",
+      )?.meta;
+      assert.deepEqual(feedStopMeta, feedStartMeta);
+    } finally {
+      await closeHarness(harness);
+    }
+  });
+
   it("supports request, signal, and feed end-to-end", async () => {
     const signals: Array<unknown> = [];
 


### PR DESCRIPTION
## Summary
- Tracks epic **scomp-vbj**: Browser transport parity across runtimes.
- Beads **scomp-vbj.1**, **scomp-vbj.4**, **scomp-vbj.5**, **scomp-vbj.3**, **scomp-vbj.2**, and **scomp-vbj.6** are implemented and merged into this epic branch.
- Feed lifecycle reliability was hardened by closing early-chunk race windows, ensuring protocol-compatible `feed_stop` teardown, and improving disconnect/error propagation for active feeds.
- Added cross-runtime conformance coverage for browser WebSocket, Node WebSocket, and RabbitMQ transports across request/signal/feed option propagation (metadata + priority), auth-context behavior, and disconnect/error-path parity assertions.
- Docs/demo alignment completed: README and migration guidance now consistently document browser transport package usage, parity guarantees, and caveats for metadata/priority/security behavior.
- develop merge conflicts were resolved on this branch and targeted validations passed after resolution.
- This Draft PR remains the rolling integration PR for all child beads under **scomp-vbj**.

## Bead References
- Epic: scomp-vbj
- Completed in this update: scomp-vbj.6

## Child Bead Progress
- [x] scomp-vbj.1 — Docs and demo alignment for browser parity
- [x] scomp-vbj.2 — Cross-runtime transport conformance tests
- [x] scomp-vbj.3 — Browser feed lifecycle reliability parity
- [x] scomp-vbj.4 — Browser transport invocation options parity
- [x] scomp-vbj.5 — Browser transport security hook parity
- [x] scomp-vbj.6 — Resolve develop merge conflicts for browser parity PR

## Deployment / Release Notes
- No direct deploy action in this PR update.
- Browser transport parity coverage now includes invocation options, security hooks, feed lifecycle reliability, cross-runtime conformance tests, docs/demo alignment, and conflict-free integration with develop.