### PR TITLE
feat(transport-rabbitmq): emit priority decision observability

### DIFF
--- a/packages/transport-rabbitmq/src/index.ts
+++ b/packages/transport-rabbitmq/src/index.ts
@@ -3,7 +3,9 @@ import { once } from "node:events";
 import {
   type CompiledRoute,
   type ITransport,
+  type ScompPriorityDecision,
   type ScompClientInvokeOptions,
+  resolveScompPriority,
 } from "@scomp/core";
 import {
   createFeedHash,
@@ -98,6 +100,15 @@ export type RabbitMQTransportEvent =
       route: string;
       operation: string;
       direction: "inbound" | "outbound";
+    }
+  | {
+      type: "priority_decision";
+      direction: "inbound" | "outbound";
+      route: string;
+      operation: ScompTransportRequestEnvelope["op"];
+      source: ScompPriorityDecision["source"];
+      requested: ScompPriorityDecision["requested"];
+      effective: ScompPriorityDecision["effective"];
     };
 
 export interface RabbitMQTransportObservabilityConfig {
@@ -251,6 +262,12 @@ export class RabbitMQTransport implements ITransport {
         const body = this.deserializeFromBuffer<ScompTransportRequestEnvelope>(
           message.content,
         );
+        this.emitPriorityDecision(
+          "inbound",
+          signalRoute.route,
+          "signal",
+          body.meta,
+        );
         const { allowed } = await this.checkSecurity({
           direction: "inbound",
           transport: "rabbitmq",
@@ -291,6 +308,7 @@ export class RabbitMQTransport implements ITransport {
   ): Promise<void> {
     const priorityMeta = toPriorityMeta(options);
     const baseMeta = this.mergeMeta(options?.meta, priorityMeta);
+    this.emitPriorityDecision("outbound", route, "signal", baseMeta);
     const { allowed, principal } = await this.checkSecurity({
       direction: "outbound",
       transport: "rabbitmq",
@@ -458,6 +476,7 @@ export class RabbitMQTransport implements ITransport {
   ): Promise<unknown> {
     const priorityMeta = toPriorityMeta(options);
     const baseMeta = this.mergeMeta(options?.meta, priorityMeta);
+    this.emitPriorityDecision("outbound", route, op, baseMeta);
     const { allowed, principal } = await this.checkSecurity({
       direction: "outbound",
       transport: "rabbitmq",
@@ -632,6 +651,7 @@ export class RabbitMQTransport implements ITransport {
       message.content,
     );
     const route = String(body.route ?? "");
+    this.emitPriorityDecision("inbound", route, body.op, body.meta);
     const { allowed } = await this.checkSecurity({
       direction: "inbound",
       transport: "rabbitmq",
@@ -989,6 +1009,28 @@ export class RabbitMQTransport implements ITransport {
 
   private emitEvent(event: RabbitMQTransportEvent): void {
     this.config.observability?.onEvent?.(event);
+  }
+
+  private emitPriorityDecision(
+    direction: "inbound" | "outbound",
+    route: string,
+    operation: ScompTransportRequestEnvelope["op"],
+    meta?: ScompTransportMessageMeta,
+  ): void {
+    const decision = resolveScompPriority({
+      route,
+      operation,
+      meta: meta as (ScompTransportMessageMeta & Record<string, unknown>) | undefined,
+    });
+    this.emitEvent({
+      type: "priority_decision",
+      direction,
+      route,
+      operation,
+      source: decision.source,
+      requested: decision.requested,
+      effective: decision.effective,
+    });
   }
 
   private now(): number {

--- a/packages/transport-rabbitmq/test/rabbitmq-transport.spec.ts
+++ b/packages/transport-rabbitmq/test/rabbitmq-transport.spec.ts
@@ -481,6 +481,192 @@ describe("RabbitMQTransport NFR behavior", () => {
     );
   });
 
+  it("emits outbound priority decision observability events", async () => {
+    const fake = createFakeChannel();
+    mockConnect.mockResolvedValue(fake.connection);
+
+    const events: Array<unknown> = [];
+    const transport = new RabbitMQTransport({
+      url: "amqp://test",
+      observability: {
+        onEvent: (event) => {
+          events.push(event);
+        },
+      },
+    });
+
+    const pendingRequest = transport.request(
+      "users.getUser",
+      { id: 1 },
+      { priorityClass: "P1" },
+    );
+    await waitFor(() => fake.channel.sendToQueue.mock.calls.length > 0);
+
+    const outboundRequestDecision = events.find(
+      (event) =>
+        event &&
+        typeof event === "object" &&
+        (event as { type?: string }).type === "priority_decision" &&
+        (event as { direction?: string }).direction === "outbound" &&
+        (event as { operation?: string }).operation === "request",
+    ) as
+      | {
+          route?: string;
+          source?: string;
+          requested?: string;
+          effective?: string;
+        }
+      | undefined;
+    assert.equal(outboundRequestDecision?.route, "users.getUser");
+    assert.equal(outboundRequestDecision?.source, "metadata_hint");
+    assert.equal(outboundRequestDecision?.requested, "P1");
+    assert.equal(outboundRequestDecision?.effective, "P1");
+
+    const [, , requestOptions] = fake.channel.sendToQueue.mock.calls[0];
+    const replyConsumer = fake.queueConsumers.get("generated-1");
+    await replyConsumer?.(
+      createMessage(
+        { payload: { ok: true } },
+        {
+          properties: {
+            correlationId: requestOptions.correlationId,
+            replyTo: requestOptions.replyTo,
+          },
+        },
+      ),
+    );
+    await pendingRequest;
+
+    await transport.signal(
+      "users.notifyLogin",
+      { id: 1 },
+      { priorityClass: "P4" },
+    );
+    const outboundSignalDecision = events.find(
+      (event) =>
+        event &&
+        typeof event === "object" &&
+        (event as { type?: string }).type === "priority_decision" &&
+        (event as { direction?: string }).direction === "outbound" &&
+        (event as { operation?: string }).operation === "signal",
+    ) as
+      | {
+          route?: string;
+          source?: string;
+          requested?: string;
+          effective?: string;
+        }
+      | undefined;
+    assert.equal(outboundSignalDecision?.route, "users.notifyLogin");
+    assert.equal(outboundSignalDecision?.source, "metadata_hint");
+    assert.equal(outboundSignalDecision?.requested, "P4");
+    assert.equal(outboundSignalDecision?.effective, "P4");
+  });
+
+  it("emits inbound priority decision observability events", async () => {
+    const fake = createFakeChannel();
+    mockConnect.mockResolvedValue(fake.connection);
+
+    const events: Array<unknown> = [];
+    const seenSignals: Array<unknown> = [];
+    const transport = new RabbitMQTransport({
+      url: "amqp://test",
+      observability: {
+        onEvent: (event) => {
+          events.push(event);
+        },
+      },
+    });
+
+    await transport.listen({
+      "users.getUser": {
+        route: "users.getUser",
+        kind: "request",
+        handler: async (payload: unknown) => payload,
+      },
+      "users.notifyLogin": {
+        route: "users.notifyLogin",
+        kind: "signal",
+        handler: async (payload: unknown) => {
+          seenSignals.push(payload);
+        },
+      },
+    } as unknown as Record<string, unknown>);
+
+    const rpcConsumer = fake.queueConsumers.get("scomp.rpc.users");
+    await rpcConsumer?.(
+      createMessage(
+        {
+          route: "users.getUser",
+          op: "request",
+          payload: { id: 3 },
+          meta: { priority: "P0" },
+        },
+        {
+          properties: {
+            correlationId: "corr-inbound-request",
+            replyTo: "reply-users",
+          },
+        },
+      ),
+    );
+
+    const inboundRequestDecision = events.find(
+      (event) =>
+        event &&
+        typeof event === "object" &&
+        (event as { type?: string }).type === "priority_decision" &&
+        (event as { direction?: string }).direction === "inbound" &&
+        (event as { operation?: string }).operation === "request",
+    ) as
+      | {
+          route?: string;
+          source?: string;
+          requested?: string;
+          effective?: string;
+        }
+      | undefined;
+    assert.equal(inboundRequestDecision?.route, "users.getUser");
+    assert.equal(inboundRequestDecision?.source, "metadata_hint");
+    assert.equal(inboundRequestDecision?.requested, "P0");
+    assert.equal(inboundRequestDecision?.effective, "P0");
+
+    const signalQueue = Array.from(fake.queueConsumers.keys()).find((queue) =>
+      queue.startsWith("scomp.event.users."),
+    );
+    assert.ok(signalQueue);
+    await fake.queueConsumers.get(String(signalQueue))?.(
+      createMessage({
+        route: "users.notifyLogin",
+        op: "signal",
+        payload: { id: 7 },
+        meta: { priorityClass: "P3" },
+      }),
+    );
+
+    assert.deepEqual(seenSignals, [{ id: 7 }]);
+
+    const inboundSignalDecision = events.find(
+      (event) =>
+        event &&
+        typeof event === "object" &&
+        (event as { type?: string }).type === "priority_decision" &&
+        (event as { direction?: string }).direction === "inbound" &&
+        (event as { operation?: string }).operation === "signal",
+    ) as
+      | {
+          route?: string;
+          source?: string;
+          requested?: string;
+          effective?: string;
+        }
+      | undefined;
+    assert.equal(inboundSignalDecision?.route, "users.notifyLogin");
+    assert.equal(inboundSignalDecision?.source, "metadata_hint");
+    assert.equal(inboundSignalDecision?.requested, "P3");
+    assert.equal(inboundSignalDecision?.effective, "P3");
+  });
+
   it("propagates inbound priority metadata to security policy", async () => {
     const fake = createFakeChannel();
     mockConnect.mockResolvedValue(fake.connection);


### PR DESCRIPTION
## Summary
- add priority_decision observability events in RabbitMQ transport using resolved priority metadata
- emit priority decisions for inbound and outbound request/signal/feed operation paths without regressing existing transport behavior
- add focused RabbitMQ tests for inbound/outbound priority decision events

## Validation
- bun run --filter='@scomp/transport-rabbitmq' test

## Beads
- scomp-e9n
- scomp-e9n.1