### PR TITLE
WIP: browser cross-window transport epic (scomp-jhv)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -82,6 +82,13 @@
         "slf": "^2.0.3",
       },
     },
+    "packages/transport-browser-windows": {
+      "name": "@scomp/transport-browser-windows",
+      "version": "0.1.0",
+      "dependencies": {
+        "@scomp/core": "workspace:*",
+      },
+    },
     "packages/transport-inprocess": {
       "name": "@scomp/transport-inprocess",
       "version": "0.1.0",
@@ -524,6 +531,8 @@
     "@scomp/demo": ["@scomp/demo@workspace:apps/demo"],
 
     "@scomp/legacy": ["@scomp/legacy@workspace:packages/scomp-legacy"],
+
+    "@scomp/transport-browser-windows": ["@scomp/transport-browser-windows@workspace:packages/transport-browser-windows"],
 
     "@scomp/transport-inprocess": ["@scomp/transport-inprocess@workspace:packages/transport-inprocess"],
 

--- a/packages/transport-browser-windows/jest.config.cjs
+++ b/packages/transport-browser-windows/jest.config.cjs
@@ -1,0 +1,8 @@
+const { createJestConfig } = require("../../jest.base.cjs");
+
+module.exports = createJestConfig({
+  rootDir: __dirname,
+  moduleNameMapper: {
+    "^@scomp/core$": "<rootDir>/../core/src",
+  },
+});

--- a/packages/transport-browser-windows/package.json
+++ b/packages/transport-browser-windows/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@scomp/transport-browser-windows",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "lint": "echo \"No lint configured for @scomp/transport-browser-windows\"",
+    "test": "jest --config jest.config.cjs --passWithNoTests"
+  },
+  "dependencies": {
+    "@scomp/core": "workspace:*"
+  }
+}

--- a/packages/transport-browser-windows/src/index.ts
+++ b/packages/transport-browser-windows/src/index.ts
@@ -1,0 +1,4 @@
+export {
+  BrowserWindowsTransport,
+  createBrowserWindowsTransport,
+} from "./transport-browser-windows";

--- a/packages/transport-browser-windows/src/transport-browser-windows.ts
+++ b/packages/transport-browser-windows/src/transport-browser-windows.ts
@@ -1,0 +1,41 @@
+import type { ITransport, ScompClientInvokeOptions } from "@scomp/core";
+
+export class BrowserWindowsTransport implements ITransport {
+  private router?: Record<string, unknown>;
+
+  listen(router: Record<string, unknown>): void {
+    this.router = router;
+  }
+
+  close(): void {
+    // no-op scaffold behavior for now
+  }
+
+  async request(
+    _route: string,
+    _payload: unknown,
+    _options?: ScompClientInvokeOptions,
+  ): Promise<unknown> {
+    throw new Error("BrowserWindowsTransport.request() not implemented");
+  }
+
+  async signal(
+    _route: string,
+    _payload: unknown,
+    _options?: ScompClientInvokeOptions,
+  ): Promise<void> {
+    throw new Error("BrowserWindowsTransport.signal() not implemented");
+  }
+
+  feed(
+    _route: string,
+    _payload: unknown,
+    _options?: ScompClientInvokeOptions,
+  ): AsyncIterable<unknown> {
+    throw new Error("BrowserWindowsTransport.feed() not implemented");
+  }
+}
+
+export function createBrowserWindowsTransport(): BrowserWindowsTransport {
+  return new BrowserWindowsTransport();
+}

--- a/packages/transport-browser-windows/tsconfig.json
+++ b/packages/transport-browser-windows/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "references": [{ "path": "../core" }],
+  "include": ["src/**/*"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,6 +5,7 @@
     { "path": "./packages/core" },
     { "path": "./packages/client" },
     { "path": "./packages/transport-rabbitmq" },
+    { "path": "./packages/transport-browser-windows" },
     { "path": "./packages/transport-inprocess" },
     { "path": "./packages/transport-websocket-client" },
     { "path": "./packages/transport-websocket-server-runtime" },


### PR DESCRIPTION
## Epic\n- Bead: scomp-jhv\n\n## Summary\n- Add new package scaffold for @scomp/transport-browser-windows\n- Establish epic decomposition and dependency plan for SharedWorker primary + BroadcastChannel fallback\n- Keep popup/user-activation transfer explicitly out of scope\n\n## Bead Plan\n- [x] scomp-j1o — Scaffold package\n- [ ] scomp-796 — Internal protocol + broker state model\n- [ ] scomp-wpm — SharedWorker request/signal/feed path\n- [ ] scomp-0p3 — BroadcastChannel fallback + election/failover\n- [ ] scomp-ght — Feed hash fanout/multiplexing\n- [ ] scomp-zxp — Security hooks + metadata precedence parity\n- [ ] scomp-2ua — Hardening (timeouts/backpressure/disconnect cleanup)\n- [ ] scomp-qhl — Jest suite with SharedWorker/BC fakes\n- [ ] scomp-aye — Docs and caveats\n\n## Status\n- scomp-j1o is verified and merged into epic branch.\n\n## Notes\n- No @scomp/core or @scomp/client API changes planned for v1.\n- This PR is the single progress surface for epic scomp-jhv.\n