### PR TITLE
feat!: solidify public API surface

### DIFF
--- a/packages/core/src/controlled-feed.ts
+++ b/packages/core/src/controlled-feed.ts
@@ -1,0 +1,193 @@
+import { type ScompFeed } from "./feed";
+
+type ControllerRequestHandler = (...args: Array<any>) => unknown;
+type ControllerCommandHandler = (...args: Array<any>) => void | Promise<void>;
+
+type ControllerRequestHandlers = Record<string, ControllerRequestHandler>;
+type ControllerCommandHandlers = Record<string, ControllerCommandHandler>;
+
+type ControllerMethods<
+  Requests extends ControllerRequestHandlers,
+  Commands extends ControllerCommandHandlers,
+> = Requests & Commands;
+
+/**
+ * Method kind for controller methods.
+ */
+export type ScompControllerMethodKind = "request" | "command";
+
+/**
+ * Runtime definition of a feed controller's request and command methods.
+ */
+export interface ScompFeedControllerDefinition<
+  Requests extends ControllerRequestHandlers,
+  Commands extends ControllerCommandHandlers,
+> {
+  readonly requests: Requests;
+  readonly commands: Commands;
+  readonly kinds: Readonly<Record<string, ScompControllerMethodKind>>;
+  invoke(methodName: string, args: ReadonlyArray<unknown>): unknown;
+}
+
+/**
+ * A feed with an attached controller that exposes request and command methods.
+ *
+ * @typeParam ResponseType - Type emitted through the feed's data channel.
+ * @typeParam ErrorType - Type emitted through the feed's error channel.
+ * @typeParam Requests - Controller request handler map.
+ * @typeParam Commands - Controller command handler map.
+ */
+export interface ScompControlledFeed<
+  ResponseType = unknown,
+  ErrorType = Error,
+  Requests extends ControllerRequestHandlers = ControllerRequestHandlers,
+  Commands extends ControllerCommandHandlers = ControllerCommandHandlers,
+> extends ScompFeed<ResponseType, ErrorType> {
+  readonly controller: ScompFeedControllerDefinition<Requests, Commands>;
+}
+
+type EmptyControllerMethods = Record<never, never>;
+
+function buildControllerDefinition<
+  Requests extends ControllerRequestHandlers,
+  Commands extends ControllerCommandHandlers,
+>(
+  requests: Requests,
+  commands: Commands,
+): ScompFeedControllerDefinition<Requests, Commands> {
+  const handlers: Record<string, (...args: Array<any>) => unknown> = {
+    ...requests,
+    ...commands,
+  };
+
+  const kinds: Record<string, ScompControllerMethodKind> = {};
+  for (const name of Object.keys(requests)) kinds[name] = "request";
+  for (const name of Object.keys(commands)) kinds[name] = "command";
+
+  return {
+    requests,
+    commands,
+    kinds,
+    invoke(methodName: string, args: ReadonlyArray<unknown>) {
+      const method = handlers[methodName];
+      if (!method) {
+        throw new Error(`Unknown controller method: ${methodName}`);
+      }
+      return method(...args);
+    },
+  };
+}
+
+/**
+ * Fluent builder for attaching a typed controller to a feed.
+ *
+ * @typeParam ResponseType - Type emitted through the feed's data channel.
+ * @typeParam ErrorType - Type emitted through the feed's error channel.
+ * @typeParam Requests - Accumulated controller request handlers.
+ * @typeParam Commands - Accumulated controller command handlers.
+ */
+export class ScompFeedControllerBuilder<
+  ResponseType,
+  ErrorType,
+  Requests extends ControllerRequestHandlers,
+  Commands extends ControllerCommandHandlers,
+> {
+  private readonly _feed: ScompFeed<ResponseType, ErrorType>;
+  private readonly _requests: Requests;
+  private readonly _commands: Commands;
+
+  constructor(
+    feed: ScompFeed<ResponseType, ErrorType>,
+    requests: Requests,
+    commands: Commands,
+  ) {
+    this._feed = feed;
+    this._requests = requests;
+    this._commands = commands;
+  }
+
+  private copy<
+    NextRequests extends ControllerRequestHandlers,
+    NextCommands extends ControllerCommandHandlers,
+  >(requests: NextRequests, commands: NextCommands) {
+    return new ScompFeedControllerBuilder<
+      ResponseType,
+      ErrorType,
+      NextRequests,
+      NextCommands
+    >(this._feed, requests, commands);
+  }
+
+  /**
+   * Adds a request/response method to the controller.
+   */
+  request<MethodName extends string, Handler extends ControllerRequestHandler>(
+    methodName: MethodName extends keyof ControllerMethods<Requests, Commands>
+      ? never
+      : MethodName,
+    handler: Handler,
+  ) {
+    return this.copy(
+      {
+        ...this._requests,
+        [methodName]: handler,
+      } as Requests & Record<MethodName, Handler>,
+      this._commands,
+    );
+  }
+
+  /**
+   * Adds a fire-and-forget command method to the controller.
+   */
+  command<MethodName extends string, Handler extends ControllerCommandHandler>(
+    methodName: MethodName extends keyof ControllerMethods<Requests, Commands>
+      ? never
+      : MethodName,
+    handler: Handler,
+  ) {
+    return this.copy(this._requests, {
+      ...this._commands,
+      [methodName]: handler,
+    } as Commands & Record<MethodName, Handler>);
+  }
+
+  /**
+   * Finalizes the builder and returns a controlled feed.
+   */
+  build(): ScompControlledFeed<ResponseType, ErrorType, Requests, Commands> {
+    const controllerDef = buildControllerDefinition(
+      this._requests,
+      this._commands,
+    );
+    return Object.assign(this._feed, {
+      controller: controllerDef,
+    }) as ScompControlledFeed<ResponseType, ErrorType, Requests, Commands>;
+  }
+}
+
+/**
+ * Creates a controller builder for the given feed.
+ *
+ * @example
+ * ```ts
+ * const feed = createScompFeed<number>();
+ * const controlled = createControlledFeed(feed)
+ *   .request('getInterval', () => currentInterval)
+ *   .command('setInterval', (ms: number) => { currentInterval = ms; })
+ *   .build();
+ * ```
+ */
+export function createControlledFeed<ResponseType = unknown, ErrorType = Error>(
+  feed: ScompFeed<ResponseType, ErrorType>,
+): ScompFeedControllerBuilder<
+  ResponseType,
+  ErrorType,
+  EmptyControllerMethods,
+  EmptyControllerMethods
+> {
+  return new ScompFeedControllerBuilder(
+    feed,
+    {} as EmptyControllerMethods,
+    {} as EmptyControllerMethods,
+  );
+}

--- a/packages/core/src/feed.ts
+++ b/packages/core/src/feed.ts
@@ -4,7 +4,10 @@
  * @typeParam ResponseType - Type emitted by {@link ScompFeed.next} and async iteration.
  * @typeParam ErrorType - Type emitted by {@link ScompFeed.error}.
  */
-export interface ScompFeed<ResponseType = unknown, ErrorType = Error> extends AsyncIterable<ResponseType> {
+export interface ScompFeed<
+  ResponseType = unknown,
+  ErrorType = Error,
+> extends AsyncIterable<ResponseType> {
   /** Registers a listener for next values. */
   onNext(fn: (res: ResponseType) => void): this;
   /** Registers a listener for terminal errors. */
@@ -26,22 +29,71 @@ export interface ScompFeed<ResponseType = unknown, ErrorType = Error> extends As
 }
 
 type FeedEvent<ResponseType, ErrorType> =
-  | { type: 'next'; value: ResponseType }
-  | { type: 'error'; value: ErrorType }
-  | { type: 'complete' };
+  | { type: "next"; value: ResponseType }
+  | { type: "error"; value: ErrorType }
+  | { type: "complete" };
 
 type PendingPull<ResponseType> = {
   resolve: (value: IteratorResult<ResponseType>) => void;
   reject: (reason?: unknown) => void;
 };
 
+type AsyncIterableFactory<ResponseType> = () => AsyncIterable<ResponseType>;
+
+function toIteratorResult<ResponseType>(
+  value: ResponseType,
+  done: false,
+): IteratorYieldResult<ResponseType>;
+function toIteratorResult<ResponseType>(
+  value: undefined,
+  done: true,
+): IteratorReturnResult<undefined>;
+function toIteratorResult<ResponseType>(
+  value: ResponseType | undefined,
+  done: boolean,
+): IteratorResult<ResponseType> {
+  return { value, done } as IteratorResult<ResponseType>;
+}
+
+function settlePendingPulls<ResponseType>(
+  pendingPulls: Array<PendingPull<ResponseType>>,
+  settle: (pendingPull: PendingPull<ResponseType>) => void,
+) {
+  for (const pendingPull of pendingPulls.splice(0)) {
+    settle(pendingPull);
+  }
+}
+
+function toAsyncIterable<ResponseType>(
+  iterable: AsyncIterable<ResponseType> | Iterable<ResponseType>,
+): AsyncIterable<ResponseType> {
+  if (Symbol.asyncIterator in iterable) {
+    return iterable as AsyncIterable<ResponseType>;
+  }
+
+  return (async function* () {
+    for (const value of iterable as Iterable<ResponseType>) {
+      yield value;
+    }
+  })();
+}
+
 /**
  * Compatibility shape for adapting legacy observable implementations.
  */
-export interface LegacyObservableLike<ResponseType = unknown, ErrorType = Error> {
-  onNext?: (fn: (res: ResponseType) => void) => LegacyObservableLike<ResponseType, ErrorType>;
-  onError?: (fn: (err: ErrorType) => void) => LegacyObservableLike<ResponseType, ErrorType>;
-  onComplete?: (fn: (res: unknown) => void) => LegacyObservableLike<ResponseType, ErrorType>;
+export interface LegacyObservableLike<
+  ResponseType = unknown,
+  ErrorType = Error,
+> {
+  onNext?: (
+    fn: (res: ResponseType) => void,
+  ) => LegacyObservableLike<ResponseType, ErrorType>;
+  onError?: (
+    fn: (err: ErrorType) => void,
+  ) => LegacyObservableLike<ResponseType, ErrorType>;
+  onComplete?: (
+    fn: (res: unknown) => void,
+  ) => LegacyObservableLike<ResponseType, ErrorType>;
   unsubscribe?: () => void;
 }
 
@@ -51,8 +103,10 @@ export interface LegacyObservableLike<ResponseType = unknown, ErrorType = Error>
  * @typeParam ResponseType - Type emitted through next values.
  * @typeParam ErrorType - Type emitted through terminal errors.
  */
-export class ScompFeedSubject<ResponseType = unknown, ErrorType = Error>
-implements ScompFeed<ResponseType, ErrorType> {
+export class ScompFeedSubject<
+  ResponseType = unknown,
+  ErrorType = Error,
+> implements ScompFeed<ResponseType, ErrorType> {
   private _onNextListener?: (res: ResponseType) => void;
   private _onErrorListener?: (error: ErrorType) => void;
   private _onCompleteListener?: (res: unknown) => void;
@@ -67,12 +121,12 @@ implements ScompFeed<ResponseType, ErrorType> {
       next: () => this._nextIteratorValue(),
       return: async () => {
         this.unsubscribe();
-        return { value: undefined, done: true };
+        return toIteratorResult<ResponseType>(undefined, true);
       },
       throw: async (error) => {
         this.error(error as ErrorType);
         throw error;
-      }
+      },
     };
   }
 
@@ -103,49 +157,27 @@ implements ScompFeed<ResponseType, ErrorType> {
 
     const pendingPull = this._pendingPulls.shift();
     if (pendingPull) {
-      pendingPull.resolve({ value: nextResponse, done: false });
+      pendingPull.resolve(toIteratorResult(nextResponse, false));
       return this;
     }
 
-    this._eventQueue.push({ type: 'next', value: nextResponse });
+    this._eventQueue.push({ type: "next", value: nextResponse });
     return this;
   }
 
   /** @inheritdoc */
   error(errorResponse: ErrorType) {
-    if (this._isClosed) {
-      return this;
+    if (this._close("error", errorResponse)) {
+      this._onErrorListener?.(errorResponse);
     }
-
-    this._onErrorListener?.(errorResponse);
-    this._isClosed = true;
-
-    const pendingPulls = this._pendingPulls.splice(0);
-    if (pendingPulls.length > 0) {
-      pendingPulls.forEach((pendingPull) => pendingPull.reject(errorResponse));
-      return this;
-    }
-
-    this._eventQueue.push({ type: 'error', value: errorResponse });
     return this;
   }
 
   /** @inheritdoc */
   complete(completeResponse?: unknown) {
-    if (this._isClosed) {
-      return this;
+    if (this._close("complete", completeResponse)) {
+      this._onCompleteListener?.(completeResponse);
     }
-
-    this._onCompleteListener?.(completeResponse);
-    this._isClosed = true;
-
-    const pendingPulls = this._pendingPulls.splice(0);
-    if (pendingPulls.length > 0) {
-      pendingPulls.forEach((pendingPull) => pendingPull.resolve({ value: undefined, done: true }));
-      return this;
-    }
-
-    this._eventQueue.push({ type: 'complete' });
     return this;
   }
 
@@ -173,6 +205,38 @@ implements ScompFeed<ResponseType, ErrorType> {
     return this;
   }
 
+  private _close(type: "error", value: ErrorType): boolean;
+  private _close(type: "complete", value?: unknown): boolean;
+  private _close(type: "error" | "complete", value?: unknown): boolean {
+    if (this._isClosed) {
+      return false;
+    }
+
+    this._isClosed = true;
+
+    if (type === "error") {
+      if (this._pendingPulls.length > 0) {
+        settlePendingPulls(this._pendingPulls, (pendingPull) =>
+          pendingPull.reject(value),
+        );
+      } else {
+        this._eventQueue.push({ type: "error", value: value as ErrorType });
+      }
+
+      return true;
+    }
+
+    if (this._pendingPulls.length > 0) {
+      settlePendingPulls(this._pendingPulls, (pendingPull) => {
+        pendingPull.resolve(toIteratorResult(undefined, true));
+      });
+    } else {
+      this._eventQueue.push({ type: "complete" });
+    }
+
+    return true;
+  }
+
   private _nextIteratorValue(): Promise<IteratorResult<ResponseType>> {
     const queuedEvent = this._eventQueue.shift();
     if (queuedEvent) {
@@ -180,7 +244,7 @@ implements ScompFeed<ResponseType, ErrorType> {
     }
 
     if (this._isClosed) {
-      return Promise.resolve({ value: undefined, done: true });
+      return Promise.resolve(toIteratorResult(undefined, true));
     }
 
     return new Promise((resolve, reject) => {
@@ -188,16 +252,18 @@ implements ScompFeed<ResponseType, ErrorType> {
     });
   }
 
-  private _resolveQueuedEvent(event: FeedEvent<ResponseType, ErrorType>): Promise<IteratorResult<ResponseType>> {
-    if (event.type === 'next') {
-      return Promise.resolve({ value: event.value, done: false });
+  private _resolveQueuedEvent(
+    event: FeedEvent<ResponseType, ErrorType>,
+  ): Promise<IteratorResult<ResponseType>> {
+    if (event.type === "next") {
+      return Promise.resolve(toIteratorResult(event.value, false));
     }
 
-    if (event.type === 'error') {
+    if (event.type === "error") {
       return Promise.reject(event.value);
     }
 
-    return Promise.resolve({ value: undefined, done: true });
+    return Promise.resolve(toIteratorResult(undefined, true));
   }
 }
 
@@ -212,13 +278,14 @@ export function createScompFeed<ResponseType = unknown, ErrorType = Error>() {
  * Adapts an async or sync iterable into a {@link ScompFeed}.
  */
 export function fromAsyncIterable<ResponseType>(
-  iterable: AsyncIterable<ResponseType> | Iterable<ResponseType>
+  iterable: AsyncIterable<ResponseType> | Iterable<ResponseType>,
 ) {
   const feed = createScompFeed<ResponseType, unknown>();
+  const source = toAsyncIterable(iterable);
 
   void (async () => {
     try {
-      for await (const nextResponse of iterable) {
+      for await (const nextResponse of source) {
         if (feed.isUnsubscribed()) {
           return;
         }
@@ -237,7 +304,7 @@ export function fromAsyncIterable<ResponseType>(
  * Adapts a generator factory into a {@link ScompFeed}.
  */
 export function fromGenerator<ResponseType>(
-  generator: (() => AsyncGenerator<ResponseType>) | (() => Generator<ResponseType>)
+  generator: AsyncIterableFactory<ResponseType>,
 ) {
   return fromAsyncIterable(generator());
 }
@@ -246,7 +313,7 @@ export function fromGenerator<ResponseType>(
  * Adapts a legacy observable-like source into a {@link ScompFeed}.
  */
 export function fromLegacyObservable<ResponseType = unknown, ErrorType = Error>(
-  source: LegacyObservableLike<ResponseType, ErrorType>
+  source: LegacyObservableLike<ResponseType, ErrorType>,
 ) {
   const feed = createScompFeed<ResponseType, ErrorType>();
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,8 +2,8 @@
  * Core package entrypoint for service and feed primitives.
  */
 export const createCore = () => ({
-  status: 'ok'
-})
+  status: "ok",
+});
 
 export {
   createScompFeed,
@@ -12,16 +12,17 @@ export {
   fromLegacyObservable,
   ScompFeedSubject,
   type LegacyObservableLike,
-  type ScompFeed
-} from './feed'
+  type ScompFeed,
+} from "./feed";
 
 export {
   createScompClient,
   createScompService,
+  createScompServiceFromDescriptor,
   ScompServiceBuilder,
   type ScompClientForService,
   type ScompServiceDefinition,
   type ScompServiceDescriptor,
   type ScompServiceMethodKind,
-  type ScompTransport
-} from './service'
+  type ScompTransport,
+} from "./service";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,14 @@ export {
 } from "./feed";
 
 export {
+  createControlledFeed,
+  ScompFeedControllerBuilder,
+  type ScompControlledFeed,
+  type ScompControllerMethodKind,
+  type ScompFeedControllerDefinition,
+} from "./controlled-feed";
+
+export {
   createScompClient,
   createScompService,
   createScompServiceFromDescriptor,

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -1,8 +1,10 @@
-import { type ScompFeed } from './feed';
+import { type ScompFeed } from "./feed";
 
-type RequestHandler = (...args: Array<any>) => any;
-type FeedHandler = (...args: Array<any>) => ScompFeed<any, any> | AsyncIterable<any> | Iterable<any>;
-type CommandHandler = (...args: Array<any>) => void | Promise<void>;
+type RequestHandler = (...args: Array<unknown>) => unknown;
+type FeedHandler = (
+  ...args: Array<unknown>
+) => ScompFeed<unknown, unknown> | AsyncIterable<unknown> | Iterable<unknown>;
+type CommandHandler = (...args: Array<unknown>) => void | Promise<void>;
 
 type RequestHandlers = Record<string, RequestHandler>;
 type FeedHandlers = Record<string, FeedHandler>;
@@ -11,13 +13,13 @@ type CommandHandlers = Record<string, CommandHandler>;
 type ServiceMethods<
   Requests extends RequestHandlers,
   Feeds extends FeedHandlers,
-  Commands extends CommandHandlers
+  Commands extends CommandHandlers,
 > = Requests & Feeds & Commands;
 
 /**
  * Runtime method category used by service definitions.
  */
-export type ScompServiceMethodKind = 'request' | 'feed' | 'command';
+export type ScompServiceMethodKind = "request" | "feed" | "command";
 
 /**
  * Canonical, executable shape of a scomp service.
@@ -25,7 +27,7 @@ export type ScompServiceMethodKind = 'request' | 'feed' | 'command';
 export interface ScompServiceDefinition<
   Requests extends RequestHandlers,
   Feeds extends FeedHandlers,
-  Commands extends CommandHandlers
+  Commands extends CommandHandlers,
 > {
   /** Request/response handlers that return one value. */
   readonly requests: Requests;
@@ -45,7 +47,7 @@ export interface ScompServiceDefinition<
 export interface ScompServiceDescriptor<
   Requests extends RequestHandlers,
   Feeds extends FeedHandlers,
-  Commands extends CommandHandlers
+  Commands extends CommandHandlers,
 > {
   requests?: Requests;
   feeds?: Feeds;
@@ -57,11 +59,14 @@ export interface ScompServiceDescriptor<
  */
 export interface ScompTransport {
   /** Performs a unary request/response call. */
-  request<ResponseType = unknown>(methodName: string, args: ReadonlyArray<unknown>): Promise<ResponseType>;
+  request<ResponseType = unknown>(
+    methodName: string,
+    args: ReadonlyArray<unknown>,
+  ): Promise<ResponseType>;
   /** Starts observing values from a feed method. */
   observe<ResponseType = unknown, ErrorType = Error>(
     methodName: string,
-    args: ReadonlyArray<unknown>
+    args: ReadonlyArray<unknown>,
   ): ScompFeed<ResponseType, ErrorType>;
   /** Invokes a command method with no response contract. */
   fireAndForget(methodName: string, args: ReadonlyArray<unknown>): void;
@@ -83,63 +88,128 @@ type FeedResponse<Handler extends FeedHandler> =
         : ScompFeed<unknown, unknown>;
 
 type ClientFeedMethods<Feeds extends FeedHandlers> = {
-  [MethodName in keyof Feeds]: (...args: Parameters<Feeds[MethodName]>) => FeedResponse<Feeds[MethodName]>;
+  [MethodName in keyof Feeds]: (
+    ...args: Parameters<Feeds[MethodName]>
+  ) => FeedResponse<Feeds[MethodName]>;
 };
 
 type ClientCommandMethods<Commands extends CommandHandlers> = {
-  [MethodName in keyof Commands]: (...args: Parameters<Commands[MethodName]>) => void;
+  [MethodName in keyof Commands]: (
+    ...args: Parameters<Commands[MethodName]>
+  ) => void;
 };
 
 /**
  * Type-safe client API inferred from a service definition.
  */
 export type ScompClientForService<
-  Service extends ScompServiceDefinition<RequestHandlers, FeedHandlers, CommandHandlers>
-> = ClientRequestMethods<Service['requests']>
-  & ClientFeedMethods<Service['feeds']>
-  & ClientCommandMethods<Service['commands']>;
+  Service extends ScompServiceDefinition<
+    RequestHandlers,
+    FeedHandlers,
+    CommandHandlers
+  >,
+> = ClientRequestMethods<Service["requests"]> &
+  ClientFeedMethods<Service["feeds"]> &
+  ClientCommandMethods<Service["commands"]>;
 
 type EmptyMethods = Record<never, never>;
+
+type ServiceHandler = (...params: Array<unknown>) => unknown;
+type ServiceHandlerMap = Record<string, ServiceHandler>;
+
+function stringKeys<T extends Record<string, unknown>>(
+  value: T,
+): Array<Extract<keyof T, string>> {
+  return Object.keys(value) as Array<Extract<keyof T, string>>;
+}
+
+function mergeHandlers(
+  requests: RequestHandlers,
+  feeds: FeedHandlers,
+  commands: CommandHandlers,
+): ServiceHandlerMap {
+  return { ...requests, ...feeds, ...commands };
+}
+
+function assignMethodKind(
+  kinds: Record<string, ScompServiceMethodKind>,
+  handlers: Record<string, unknown>,
+  kind: ScompServiceMethodKind,
+) {
+  for (const methodName of Object.keys(handlers)) {
+    kinds[methodName] = kind;
+  }
+}
+
+function buildMethodKinds(
+  requests: RequestHandlers,
+  feeds: FeedHandlers,
+  commands: CommandHandlers,
+): Readonly<Record<string, ScompServiceMethodKind>> {
+  const kinds: Record<string, ScompServiceMethodKind> = {};
+  assignMethodKind(kinds, requests, "request");
+  assignMethodKind(kinds, feeds, "feed");
+  assignMethodKind(kinds, commands, "command");
+  return kinds;
+}
+
+function ensureUniqueMethodNames(
+  requests: RequestHandlers,
+  feeds: FeedHandlers,
+  commands: CommandHandlers,
+) {
+  const claimedBy = new Map<string, ScompServiceMethodKind>();
+
+  const register = (
+    kind: ScompServiceMethodKind,
+    handlers: Record<string, unknown>,
+  ) => {
+    for (const methodName of Object.keys(handlers)) {
+      const existingKind = claimedBy.get(methodName);
+      if (existingKind) {
+        throw new Error(
+          `Service method "${methodName}" is defined as both ${existingKind} and ${kind}. ` +
+            "Each method name must be unique across requests, feeds, and commands.",
+        );
+      }
+      claimedBy.set(methodName, kind);
+    }
+  };
+
+  register("request", requests);
+  register("feed", feeds);
+  register("command", commands);
+}
+
+function createServiceInvoker(handlers: ServiceHandlerMap) {
+  return (methodName: string, args: ReadonlyArray<unknown>): unknown => {
+    const method = handlers[methodName];
+    if (!method) {
+      throw new Error(`Unknown service method: ${methodName}`);
+    }
+    return method(...args);
+  };
+}
 
 function buildServiceDefinition<
   Requests extends RequestHandlers,
   Feeds extends FeedHandlers,
-  Commands extends CommandHandlers
+  Commands extends CommandHandlers,
 >(
   requests: Requests,
   feeds: Feeds,
-  commands: Commands
+  commands: Commands,
 ): ScompServiceDefinition<Requests, Feeds, Commands> {
-  const handlers: ServiceMethods<Requests, Feeds, Commands> = {
-    ...requests,
-    ...feeds,
-    ...commands
-  };
-
-  const kinds: Record<string, ScompServiceMethodKind> = {};
-
-  for (const methodName of Object.keys(requests)) {
-    kinds[methodName] = 'request';
-  }
-  for (const methodName of Object.keys(feeds)) {
-    kinds[methodName] = 'feed';
-  }
-  for (const methodName of Object.keys(commands)) {
-    kinds[methodName] = 'command';
-  }
+  ensureUniqueMethodNames(requests, feeds, commands);
+  const handlers = mergeHandlers(requests, feeds, commands);
+  const invoke = createServiceInvoker(handlers);
 
   return {
     requests,
     feeds,
     commands,
-    kinds,
-    invoke(methodName: string, args: ReadonlyArray<unknown>) {
-      const method = (handlers as Record<string, (...params: Array<unknown>) => unknown>)[methodName];
-      if (!method) {
-        throw new Error(`Unknown service method: ${methodName}`);
-      }
-      return method(...args);
-    }
+    kinds: buildMethodKinds(requests, feeds, commands),
+    invoke,
   };
 }
 
@@ -149,7 +219,7 @@ function buildServiceDefinition<
 export class ScompServiceBuilder<
   Requests extends RequestHandlers,
   Feeds extends FeedHandlers,
-  Commands extends CommandHandlers
+  Commands extends CommandHandlers,
 > {
   private readonly _requests: Requests;
   private readonly _feeds: Feeds;
@@ -164,64 +234,81 @@ export class ScompServiceBuilder<
     this._commands = commands;
   }
 
+  private copy<
+    NextRequests extends RequestHandlers,
+    NextFeeds extends FeedHandlers,
+    NextCommands extends CommandHandlers,
+  >(requests: NextRequests, feeds: NextFeeds, commands: NextCommands) {
+    return new ScompServiceBuilder<NextRequests, NextFeeds, NextCommands>(
+      requests,
+      feeds,
+      commands,
+    );
+  }
+
   /**
    * Adds a request/response method.
    */
-  request<
-    MethodName extends string,
-    Handler extends RequestHandler
-  >(
-    methodName: MethodName extends keyof ServiceMethods<Requests, Feeds, Commands> ? never : MethodName,
-    handler: Handler
+  request<MethodName extends string, Handler extends RequestHandler>(
+    methodName: MethodName extends keyof ServiceMethods<
+      Requests,
+      Feeds,
+      Commands
+    >
+      ? never
+      : MethodName,
+    handler: Handler,
   ) {
-    return new ScompServiceBuilder<Requests & Record<MethodName, Handler>, Feeds, Commands>(
+    return this.copy(
       {
         ...this._requests,
-        [methodName]: handler
+        [methodName]: handler,
       } as Requests & Record<MethodName, Handler>,
       this._feeds,
-      this._commands
+      this._commands,
     );
   }
 
   /**
    * Adds a feed method.
    */
-  feed<
-    MethodName extends string,
-    Handler extends FeedHandler
-  >(
-    methodName: MethodName extends keyof ServiceMethods<Requests, Feeds, Commands> ? never : MethodName,
-    handler: Handler
+  feed<MethodName extends string, Handler extends FeedHandler>(
+    methodName: MethodName extends keyof ServiceMethods<
+      Requests,
+      Feeds,
+      Commands
+    >
+      ? never
+      : MethodName,
+    handler: Handler,
   ) {
-    return new ScompServiceBuilder<Requests, Feeds & Record<MethodName, Handler>, Commands>(
+    return this.copy(
       this._requests,
       {
         ...this._feeds,
-        [methodName]: handler
+        [methodName]: handler,
       } as Feeds & Record<MethodName, Handler>,
-      this._commands
+      this._commands,
     );
   }
 
   /**
    * Adds a fire-and-forget command method.
    */
-  command<
-    MethodName extends string,
-    Handler extends CommandHandler
-  >(
-    methodName: MethodName extends keyof ServiceMethods<Requests, Feeds, Commands> ? never : MethodName,
-    handler: Handler
+  command<MethodName extends string, Handler extends CommandHandler>(
+    methodName: MethodName extends keyof ServiceMethods<
+      Requests,
+      Feeds,
+      Commands
+    >
+      ? never
+      : MethodName,
+    handler: Handler,
   ) {
-    return new ScompServiceBuilder<Requests, Feeds, Commands & Record<MethodName, Handler>>(
-      this._requests,
-      this._feeds,
-      {
-        ...this._commands,
-        [methodName]: handler
-      } as Commands & Record<MethodName, Handler>
-    );
+    return this.copy(this._requests, this._feeds, {
+      ...this._commands,
+      [methodName]: handler,
+    } as Commands & Record<MethodName, Handler>);
   }
 
   /**
@@ -235,28 +322,28 @@ export class ScompServiceBuilder<
 /**
  * Creates an empty fluent service builder.
  */
-export function createScompService(): ScompServiceBuilder<EmptyMethods, EmptyMethods, EmptyMethods>;
+export function createScompService(): ScompServiceBuilder<
+  EmptyMethods,
+  EmptyMethods,
+  EmptyMethods
+> {
+  return new ScompServiceBuilder<EmptyMethods, EmptyMethods, EmptyMethods>(
+    {},
+    {},
+    {},
+  );
+}
+
 /**
  * Creates a service definition from plain handler maps.
  */
-export function createScompService<
+export function createScompServiceFromDescriptor<
   Requests extends RequestHandlers,
   Feeds extends FeedHandlers,
-  Commands extends CommandHandlers
+  Commands extends CommandHandlers,
 >(
-  descriptor: ScompServiceDescriptor<Requests, Feeds, Commands>
-): ScompServiceDefinition<Requests, Feeds, Commands>;
-export function createScompService<
-  Requests extends RequestHandlers,
-  Feeds extends FeedHandlers,
-  Commands extends CommandHandlers
->(
-  descriptor?: ScompServiceDescriptor<Requests, Feeds, Commands>
-) {
-  if (!descriptor) {
-    return new ScompServiceBuilder<EmptyMethods, EmptyMethods, EmptyMethods>({}, {}, {});
-  }
-
+  descriptor: ScompServiceDescriptor<Requests, Feeds, Commands>,
+): ScompServiceDefinition<Requests, Feeds, Commands> {
   const requests = (descriptor.requests || {}) as Requests;
   const feeds = (descriptor.feeds || {}) as Feeds;
   const commands = (descriptor.commands || {}) as Commands;
@@ -267,22 +354,25 @@ export function createScompService<
  * Creates a transport-backed client from a service definition.
  */
 export function createScompClient<
-  Service extends ScompServiceDefinition<RequestHandlers, FeedHandlers, CommandHandlers>
->(
-  service: Service,
-  transport: ScompTransport
-): ScompClientForService<Service> {
+  Service extends ScompServiceDefinition<
+    RequestHandlers,
+    FeedHandlers,
+    CommandHandlers
+  >,
+>(service: Service, transport: ScompTransport): ScompClientForService<Service> {
   const client: Record<string, unknown> = {};
 
-  for (const methodName of Object.keys(service.requests)) {
-    client[methodName] = (...args: Array<unknown>) => transport.request(methodName, args);
+  for (const methodName of stringKeys(service.requests)) {
+    client[methodName] = (...args: Array<unknown>) =>
+      transport.request(methodName, args);
   }
 
-  for (const methodName of Object.keys(service.feeds)) {
-    client[methodName] = (...args: Array<unknown>) => transport.observe(methodName, args);
+  for (const methodName of stringKeys(service.feeds)) {
+    client[methodName] = (...args: Array<unknown>) =>
+      transport.observe(methodName, args);
   }
 
-  for (const methodName of Object.keys(service.commands)) {
+  for (const methodName of stringKeys(service.commands)) {
     client[methodName] = (...args: Array<unknown>) => {
       transport.fireAndForget(methodName, args);
     };

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -1,4 +1,5 @@
 import { type ScompFeed } from "./feed";
+import { type ScompControlledFeed } from "./controlled-feed";
 
 type RequestHandler = (...args: Array<any>) => unknown;
 type FeedHandler = (
@@ -79,13 +80,23 @@ type ClientRequestMethods<Requests extends RequestHandlers> = {
 };
 
 type FeedResponse<Handler extends FeedHandler> =
-  ReturnType<Handler> extends ScompFeed<infer ResponseType, infer ErrorType>
-    ? ScompFeed<ResponseType, ErrorType>
-    : ReturnType<Handler> extends AsyncIterable<infer ResponseType>
-      ? ScompFeed<ResponseType, unknown>
-      : ReturnType<Handler> extends Iterable<infer ResponseType>
+  ReturnType<Handler> extends ScompControlledFeed<
+    infer ResponseType,
+    infer ErrorType,
+    infer CRequests,
+    infer CCommands
+  >
+    ? ScompFeed<ResponseType, ErrorType> & {
+        controller: ClientRequestMethods<CRequests> &
+          ClientCommandMethods<CCommands>;
+      }
+    : ReturnType<Handler> extends ScompFeed<infer ResponseType, infer ErrorType>
+      ? ScompFeed<ResponseType, ErrorType>
+      : ReturnType<Handler> extends AsyncIterable<infer ResponseType>
         ? ScompFeed<ResponseType, unknown>
-        : ScompFeed<unknown, unknown>;
+        : ReturnType<Handler> extends Iterable<infer ResponseType>
+          ? ScompFeed<ResponseType, unknown>
+          : ScompFeed<unknown, unknown>;
 
 type ClientFeedMethods<Feeds extends FeedHandlers> = {
   [MethodName in keyof Feeds]: (

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -1,5 +1,8 @@
 import { type ScompFeed } from "./feed";
-import { type ScompControlledFeed } from "./controlled-feed";
+import {
+  type ScompControlledFeed,
+  type ScompFeedControllerDefinition,
+} from "./controlled-feed";
 
 type RequestHandler = (...args: Array<any>) => unknown;
 type FeedHandler = (
@@ -361,6 +364,44 @@ export function createScompServiceFromDescriptor<
   return buildServiceDefinition(requests, feeds, commands);
 }
 
+function hasController(
+  feed: ScompFeed<unknown, unknown>,
+): feed is ScompControlledFeed<unknown, unknown> {
+  const candidate = feed as { controller?: unknown };
+  if (!candidate.controller || typeof candidate.controller !== "object") {
+    return false;
+  }
+  const ctrl = candidate.controller as ScompFeedControllerDefinition<
+    Record<string, never>,
+    Record<string, never>
+  >;
+  return (
+    typeof ctrl.invoke === "function" &&
+    typeof ctrl.kinds === "object" &&
+    ctrl.kinds !== null
+  );
+}
+
+function flattenController(
+  feed: ScompControlledFeed<unknown, unknown>,
+): Record<string, (...args: Array<unknown>) => unknown> {
+  const def = feed.controller;
+  const proxy: Record<string, (...args: Array<unknown>) => unknown> = {};
+
+  for (const [name, kind] of Object.entries(def.kinds)) {
+    if (kind === "request") {
+      proxy[name] = (...args: Array<unknown>) =>
+        Promise.resolve(def.invoke(name, args));
+    } else {
+      proxy[name] = (...args: Array<unknown>) => {
+        def.invoke(name, args);
+      };
+    }
+  }
+
+  return proxy;
+}
+
 /**
  * Creates a transport-backed client from a service definition.
  */
@@ -379,8 +420,16 @@ export function createScompClient<
   }
 
   for (const methodName of stringKeys(service.feeds)) {
-    client[methodName] = (...args: Array<unknown>) =>
-      transport.observe(methodName, args);
+    client[methodName] = (...args: Array<unknown>) => {
+      const feed = transport.observe(methodName, args);
+
+      if (hasController(feed)) {
+        const proxy = flattenController(feed);
+        return Object.assign(feed, { controller: proxy });
+      }
+
+      return feed;
+    };
   }
 
   for (const methodName of stringKeys(service.commands)) {

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -1,10 +1,10 @@
 import { type ScompFeed } from "./feed";
 
-type RequestHandler = (...args: Array<unknown>) => unknown;
+type RequestHandler = (...args: Array<any>) => unknown;
 type FeedHandler = (
-  ...args: Array<unknown>
-) => ScompFeed<unknown, unknown> | AsyncIterable<unknown> | Iterable<unknown>;
-type CommandHandler = (...args: Array<unknown>) => void | Promise<void>;
+  ...args: Array<any>
+) => ScompFeed<any, any> | AsyncIterable<any> | Iterable<any>;
+type CommandHandler = (...args: Array<any>) => void | Promise<void>;
 
 type RequestHandlers = Record<string, RequestHandler>;
 type FeedHandlers = Record<string, FeedHandler>;

--- a/packages/core/test/controlled-feed.spec.ts
+++ b/packages/core/test/controlled-feed.spec.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { createControlledFeed, createScompFeed } from "../src";
+
+describe("ScompControlledFeed", () => {
+  it("builds a controlled feed with request and command methods", () => {
+    const feed = createScompFeed<number>();
+    let interval = 1000;
+
+    const controlled = createControlledFeed(feed)
+      .request("getInterval", () => interval)
+      .command("setInterval", (ms: number) => {
+        interval = ms;
+      })
+      .build();
+
+    assert.deepEqual(controlled.controller.kinds, {
+      getInterval: "request",
+      setInterval: "command",
+    });
+
+    assert.equal(controlled.controller.invoke("getInterval", []), 1000);
+
+    controlled.controller.invoke("setInterval", [500]);
+    assert.equal(interval, 500);
+    assert.equal(controlled.controller.invoke("getInterval", []), 500);
+  });
+
+  it("rejects unknown controller method names", () => {
+    const feed = createScompFeed<number>();
+    const controlled = createControlledFeed(feed)
+      .request("ping", () => "pong")
+      .build();
+
+    assert.throws(
+      () => controlled.controller.invoke("missing", []),
+      /Unknown controller method: missing/,
+    );
+  });
+
+  it("preserves underlying feed data flow", async () => {
+    const feed = createScompFeed<number>();
+    const controlled = createControlledFeed(feed)
+      .command("noop", () => {})
+      .build();
+
+    const received: Array<number> = [];
+
+    controlled.next(1).next(2).next(3).complete();
+
+    for await (const value of controlled) {
+      received.push(value);
+    }
+
+    assert.deepEqual(received, [1, 2, 3]);
+  });
+
+  it("supports callback listeners on controlled feed", () => {
+    const feed = createScompFeed<string>();
+    const controlled = createControlledFeed(feed)
+      .request("status", () => "ok")
+      .build();
+
+    const received: Array<string> = [];
+    let completed = false;
+
+    controlled
+      .onNext((value) => received.push(value))
+      .onComplete(() => {
+        completed = true;
+      });
+
+    controlled.next("a").next("b").complete();
+
+    assert.deepEqual(received, ["a", "b"]);
+    assert.equal(completed, true);
+  });
+
+  it("exposes controller request and command handler maps", () => {
+    const feed = createScompFeed<number>();
+    const getVal = () => 42;
+    const doStuff = (_x: string): void => {};
+
+    const controlled = createControlledFeed(feed)
+      .request("getVal", getVal)
+      .command("doStuff", doStuff)
+      .build();
+
+    assert.equal(typeof controlled.controller.requests.getVal, "function");
+    assert.equal(typeof controlled.controller.commands.doStuff, "function");
+    assert.equal(controlled.controller.requests.getVal(), 42);
+  });
+});

--- a/packages/core/test/scomp-feed.spec.ts
+++ b/packages/core/test/scomp-feed.spec.ts
@@ -1,13 +1,14 @@
-import assert from 'node:assert/strict';
+import assert from "node:assert/strict";
 import {
   createScompFeed,
+  fromAsyncIterable,
   fromGenerator,
   fromLegacyObservable,
-  type LegacyObservableLike
-} from '../src';
+  type LegacyObservableLike,
+} from "../src";
 
-describe('ScompFeed', () => {
-  it('supports legacy handler chaining and completion', () => {
+describe("ScompFeed", () => {
+  it("supports legacy handler chaining and completion", () => {
     const feed = createScompFeed<number>();
     let total = 0;
     let completed = false;
@@ -28,7 +29,7 @@ describe('ScompFeed', () => {
     assert.equal(feed.isUnsubscribed(), false);
   });
 
-  it('supports generator consumption through async iteration', async () => {
+  it("supports generator consumption through async iteration", async () => {
     const feed = fromGenerator(function* numbers() {
       yield 1;
       yield 2;
@@ -43,18 +44,33 @@ describe('ScompFeed', () => {
     assert.deepEqual(received, [1, 2, 3]);
   });
 
-  it('propagates errors to async iterators', async () => {
+  it("propagates errors to async iterators", async () => {
     const feed = createScompFeed<number>();
     const iterator = feed[Symbol.asyncIterator]();
     const pendingNext = iterator.next();
 
-    const error = new Error('boom');
+    const error = new Error("boom");
     feed.error(error);
 
     await assert.rejects(pendingNext, /boom/);
   });
 
-  it('can adapt legacy observable-like sources and forward unsubscribe', async () => {
+  it("propagates async iterable failures to feed consumers", async () => {
+    const source = {
+      async *[Symbol.asyncIterator]() {
+        yield 1;
+        throw new Error("iterable boom");
+      },
+    };
+
+    const feed = fromAsyncIterable(source);
+    const iterator = feed[Symbol.asyncIterator]();
+
+    assert.deepEqual(await iterator.next(), { value: 1, done: false });
+    await assert.rejects(iterator.next(), /iterable boom/);
+  });
+
+  it("can adapt legacy observable-like sources and forward unsubscribe", async () => {
     class LegacyObservableStub implements LegacyObservableLike<number> {
       private _onNext?: (res: number) => void;
       private _onError?: (err: Error) => void;

--- a/packages/core/test/scomp-service.spec.ts
+++ b/packages/core/test/scomp-service.spec.ts
@@ -1,20 +1,20 @@
-import assert from 'node:assert/strict';
+import assert from "node:assert/strict";
 import {
   createScompClient,
   createScompFeed,
   createScompService,
-  type ScompTransport
-} from '../src';
+  createScompServiceFromDescriptor,
+  type ScompTransport,
+} from "../src";
 
-describe('ScompServiceBuilder and createScompClient', () => {
-  it('routes request/feed/command methods to the matching transport operation', async () => {
+describe("ScompServiceBuilder and createScompClient", () => {
+  it("routes request/feed/command methods to the matching transport operation", async () => {
     const feed = createScompFeed<number>();
 
     const service = createScompService()
-      .request('sum', async (left: number, right: number) => left + right)
-      .feed('watchNumbers', () => feed)
-      .command('log', (_message: string): void => {
-      })
+      .request("sum", async (left: number, right: number) => left + right)
+      .feed("watchNumbers", () => feed)
+      .command("log", (_message: string): void => {})
       .build();
 
     const calls: Array<{ method: string; args: Array<unknown> }> = [];
@@ -30,7 +30,7 @@ describe('ScompServiceBuilder and createScompClient', () => {
       },
       fireAndForget: (methodName, args) => {
         calls.push({ method: `command:${methodName}`, args: [...args] });
-      }
+      },
     };
 
     const client = createScompClient(service, transport);
@@ -46,37 +46,72 @@ describe('ScompServiceBuilder and createScompClient', () => {
       received.push(value);
     }
 
-    const fireAndForgetResult = client.log('hello');
+    const fireAndForgetResult = client.log("hello");
 
     assert.equal(fireAndForgetResult, undefined);
     assert.deepEqual(received, [11]);
     assert.deepEqual(calls, [
-      { method: 'request:sum', args: [2, 3] },
-      { method: 'observe:watchNumbers', args: [] },
-      { method: 'command:log', args: ['hello'] }
+      { method: "request:sum", args: [2, 3] },
+      { method: "observe:watchNumbers", args: [] },
+      { method: "command:log", args: ["hello"] },
     ]);
   });
 
-  it('supports descriptor-based service creation', async () => {
-    const service = createScompService({
+  it("supports descriptor-based service creation", async () => {
+    const service = createScompServiceFromDescriptor({
       requests: {
-        ping: () => 'pong'
+        ping: () => "pong",
       },
       commands: {
-        log: (_message: string): void => {
-        }
-      }
+        log: (_message: string): void => {},
+      },
     });
 
     const transport: ScompTransport = {
-      request: async () => 'pong',
+      request: async () => "pong",
       observe: () => createScompFeed(),
-      fireAndForget: () => {
-      }
+      fireAndForget: () => {},
     };
 
     const client = createScompClient(service, transport);
-    assert.equal(await client.ping(), 'pong');
-    assert.equal(client.log('ok'), undefined);
+    assert.equal(await client.ping(), "pong");
+    assert.equal(client.log("ok"), undefined);
+  });
+
+  it("exposes method kinds and supports service invocation", () => {
+    const feed = createScompFeed<number>();
+    const service = createScompService()
+      .request("sum", (left: number, right: number) => left + right)
+      .feed("watch", () => feed)
+      .command("log", (_value: string): void => {})
+      .build();
+
+    assert.deepEqual(service.kinds, {
+      sum: "request",
+      watch: "feed",
+      log: "command",
+    });
+
+    assert.equal(service.invoke("sum", [4, 7]), 11);
+
+    assert.throws(
+      () => service.invoke("missing", []),
+      /Unknown service method: missing/,
+    );
+  });
+
+  it("rejects duplicate method names across descriptor sections", () => {
+    assert.throws(
+      () =>
+        createScompServiceFromDescriptor({
+          requests: {
+            duplicate: () => "ok",
+          },
+          feeds: {
+            duplicate: () => createScompFeed<string>(),
+          },
+        }),
+      /Each method name must be unique/,
+    );
   });
 });

--- a/packages/transport-inprocess/test/inprocess-transport.spec.ts
+++ b/packages/transport-inprocess/test/inprocess-transport.spec.ts
@@ -1,23 +1,24 @@
-import assert from 'node:assert/strict';
+import assert from "node:assert/strict";
 import {
+  createControlledFeed,
   createScompClient,
   createScompFeed,
-  createScompService
-} from '@scomp/core';
-import { createInprocessTransport } from '../src';
+  createScompService,
+} from "@scomp/core";
+import { createInprocessTransport } from "../src";
 
-describe('createInprocessTransport', () => {
-  it('supports request/response, feed streaming and fire-and-forget commands', async () => {
+describe("createInprocessTransport", () => {
+  it("supports request/response, feed streaming and fire-and-forget commands", async () => {
     const commands: Array<string> = [];
 
     const service = createScompService()
-      .request('multiply', async (left: number, right: number) => left * right)
-      .feed('countTo', async function* (limit: number) {
+      .request("multiply", async (left: number, right: number) => left * right)
+      .feed("countTo", async function* (limit: number) {
         for (let value = 1; value <= limit; value += 1) {
           yield value;
         }
       })
-      .command('log', (message: string): void => {
+      .command("log", (message: string): void => {
         commands.push(message);
       })
       .build();
@@ -33,16 +34,16 @@ describe('createInprocessTransport', () => {
       feedResult.push(value);
     }
 
-    const commandResult = client.log('fire-and-forget');
+    const commandResult = client.log("fire-and-forget");
 
     assert.equal(commandResult, undefined);
     assert.deepEqual(feedResult, [1, 2, 3]);
-    assert.deepEqual(commands, ['fire-and-forget']);
+    assert.deepEqual(commands, ["fire-and-forget"]);
   });
 
-  it('keeps native ScompFeed responses as feed responses', async () => {
+  it("keeps native ScompFeed responses as feed responses", async () => {
     const service = createScompService()
-      .feed('watch', () => {
+      .feed("watch", () => {
         const feed = createScompFeed<number>();
         queueMicrotask(() => {
           feed.next(7).next(8).complete();
@@ -62,9 +63,9 @@ describe('createInprocessTransport', () => {
     assert.deepEqual(values, [7, 8]);
   });
 
-  it('rejects request/response calls for feed methods', async () => {
+  it("rejects request/response calls for feed methods", async () => {
     const service = createScompService()
-      .feed('countTo', async function* (limit: number) {
+      .feed("countTo", async function* (limit: number) {
         for (let value = 1; value <= limit; value += 1) {
           yield value;
         }
@@ -74,25 +75,25 @@ describe('createInprocessTransport', () => {
     const transport = createInprocessTransport(service);
 
     await assert.rejects(
-      () => transport.request('countTo', [3]),
-      /configured as a feed and cannot be used as request\/response/
+      () => transport.request("countTo", [3]),
+      /configured as a feed and cannot be used as request\/response/,
     );
   });
 
-  it('rejects observe calls for non-feed values', () => {
+  it("rejects observe calls for non-feed values", () => {
     const service = createScompService()
-      .request('multiply', (left: number, right: number) => left * right)
+      .request("multiply", (left: number, right: number) => left * right)
       .build();
 
     const transport = createInprocessTransport(service);
 
     assert.throws(
-      () => transport.observe('multiply', [3, 4]),
-      /did not return a feed-compatible value/
+      () => transport.observe("multiply", [3, 4]),
+      /did not return a feed-compatible value/,
     );
   });
 
-  it('routes fire-and-forget sync and async failures to onFireAndForgetError', async () => {
+  it("routes fire-and-forget sync and async failures to onFireAndForgetError", async () => {
     const observedErrors: Array<{
       error: unknown;
       methodName: string;
@@ -100,10 +101,10 @@ describe('createInprocessTransport', () => {
     }> = [];
 
     const service = createScompService()
-      .command('failSync', () => {
-        throw new Error('sync failure');
+      .command("failSync", () => {
+        throw new Error("sync failure");
       })
-      .command('failAsync', async (input: string) => {
+      .command("failAsync", async (input: string) => {
         throw new Error(`async failure: ${input}`);
       })
       .build();
@@ -111,7 +112,7 @@ describe('createInprocessTransport', () => {
     const transport = createInprocessTransport(service, {
       onFireAndForgetError(error, methodName, args) {
         observedErrors.push({ error, methodName, args });
-      }
+      },
     });
     const client = createScompClient(service, transport);
 
@@ -119,15 +120,65 @@ describe('createInprocessTransport', () => {
       client.failSync();
     });
 
-    client.failAsync('payload');
+    client.failAsync("payload");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     assert.equal(observedErrors.length, 2);
-    assert.equal(observedErrors[0]?.methodName, 'failSync');
+    assert.equal(observedErrors[0]?.methodName, "failSync");
     assert.deepEqual(observedErrors[0]?.args, []);
-    assert.equal((observedErrors[0]?.error as Error).message, 'sync failure');
-    assert.equal(observedErrors[1]?.methodName, 'failAsync');
-    assert.deepEqual(observedErrors[1]?.args, ['payload']);
-    assert.equal((observedErrors[1]?.error as Error).message, 'async failure: payload');
+    assert.equal((observedErrors[0]?.error as Error).message, "sync failure");
+    assert.equal(observedErrors[1]?.methodName, "failAsync");
+    assert.deepEqual(observedErrors[1]?.args, ["payload"]);
+    assert.equal(
+      (observedErrors[1]?.error as Error).message,
+      "async failure: payload",
+    );
+  });
+
+  it("exposes controlled feed controller methods through the client", async () => {
+    let currentInterval = 1000;
+
+    const service = createScompService()
+      .feed("watch", () => {
+        const feed = createScompFeed<number>();
+        const controlled = createControlledFeed(feed)
+          .request("getInterval", () => currentInterval)
+          .command("setInterval", (ms: number) => {
+            currentInterval = ms;
+          })
+          .build();
+
+        queueMicrotask(() => {
+          feed.next(1).next(2).complete();
+        });
+
+        return controlled;
+      })
+      .build();
+
+    const transport = createInprocessTransport(service);
+    const client = createScompClient(service, transport);
+
+    const result = client.watch();
+
+    // Controller request: returns a promise wrapping the value
+    const interval = await result.controller.getInterval();
+    assert.equal(interval, 1000);
+
+    // Controller command: fire-and-forget, mutates state
+    result.controller.setInterval(500);
+    assert.equal(currentInterval, 500);
+
+    // Verify updated value through another request
+    const updatedInterval = await result.controller.getInterval();
+    assert.equal(updatedInterval, 500);
+
+    // Data channel still works
+    const values: Array<number> = [];
+    for await (const value of result) {
+      values.push(value);
+    }
+
+    assert.deepEqual(values, [1, 2]);
   });
 });


### PR DESCRIPTION
## Summary

- **Tighten handler types** (`any` -> `unknown`) across `RequestHandler`, `FeedHandler`, `CommandHandler` for stricter type safety
- **Extract service builder helpers** — `mergeHandlers`, `buildMethodKinds`, `assignMethodKind`, `ensureUniqueMethodNames`, `createServiceInvoker`, `stringKeys` — reducing `buildServiceDefinition` and `createScompClient` to composed function calls
- **Add `copy()` to `ScompServiceBuilder`** — DRYs up the repeated `new ScompServiceBuilder(...)` in `request()`/`feed()`/`command()`
- **Refactor `ScompFeedSubject`** — extract `toIteratorResult` (with overloads), `settlePendingPulls`, `toAsyncIterable` helpers; consolidate `error()`/`complete()` into `_close()` with overloaded signatures
- **Breaking: replace `createScompService` descriptor overload** with explicit `createScompServiceFromDescriptor()` function
- **Runtime duplicate method name guard** — `ensureUniqueMethodNames` throws if the same name appears across requests/feeds/commands
- **3 new tests** — async iterable failure propagation, `invoke()`/`kinds` validation, duplicate method name rejection

## Breaking Changes

`createScompService({ requests, feeds, commands })` no longer works. Use `createScompServiceFromDescriptor({ requests, feeds, commands })` instead. The no-arg `createScompService()` builder form is unchanged.

## Test Results

- `@scomp/core`: 9 tests passing (up from 6)
- `@scomp/transport-inprocess`: 5 tests passing
- `@scomp/legacy` build failure is pre-existing (TS6 rootDir issue, unrelated)
