### PR TITLE
docs: add v2 architecture ADR and update guides for peer model API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,102 +2,156 @@
 
 SCOMP is a transport-agnostic RPC toolkit with first-class `request`, `signal`, and `feed` semantics.
 
-Typed service contract + transport toolkit.
+Typed service contracts bound to runtime tokens. Symmetric peer model. Controlled feeds with typed controllers.
 
 ## LLM/contributor guides
 
 - [llms.txt](llms.txt) — practical SCOMP mental model, modern API usage, transport matrix, security caveats, and common mistakes.
 - [docs/llms-transports.md](docs/llms-transports.md) — concise runnable transport setup patterns.
 
-## Validation commands (browser transport quality gates)
+## Validation commands
 
-- `npm run lint`
-- `npm test`
-- `bun run --filter='@scomp/transport-browser-windows' test`
-- `bun run --filter='@scomp/transport-browser-windows' lint`
+```bash
+bunx turbo run build    # build all packages
+bunx turbo run test     # run all tests
+bunx turbo run lint     # lint all packages
+```
 
-## Default authoring model (strict + grouped)
+## Core concepts
 
-SCOMP defaults to **strict, grouped service authoring** with three operation sections:
+### Contract tokens
 
-- `requests`
-- `signals`
-- `feeds`
-
-Use `createScompService` to define a full service. In strict mode, every contract method must be implemented and grouped under the correct section.
+A contract token binds a TypeScript contract type to a service name at runtime:
 
 ```ts
-import { createScompService } from '@scomp/core';
+import { createContractToken } from "@scomp/core";
 
-interface UsersContract {
+type UsersContract = {
   getUser(input: { id: number }): Promise<{ id: number; name: string }>;
   notifyLogin(input: { id: number; at: string }): Promise<void>;
   liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
-}
+};
 
-const usersService = createScompService<UsersContract>('users').implement({
-  requests: {
-    getUser: async ({ id }) => ({ id, name: `user-${id}` })
-  },
-  signals: {
-    notifyLogin: async ({ id, at }) => {
-      console.log('login', { id, at });
-    }
-  },
-  feeds: {
-    liveUsers: {
-      strategy: 'fanout',
-      handler: async function* () {
-        yield { id: 1 };
-      }
-    }
-  }
-});
+const Users = createContractToken<UsersContract>("users");
 ```
 
-## Fragment composition flow
+### Peer model
 
-Use **fragments** for partial/domain-local implementation, then compose them with `composeScompFragments`.
+A peer is a symmetric node that can host services and/or call remote services:
 
 ```ts
-import { createScompFragment, composeScompFragments } from '@scomp/core';
+import { createScompPeer, createScompService } from "@scomp/core";
 
-const usersRequests = createScompFragment<UsersContract>('users').implement({
-  requests: {
-    getUser: async ({ id }) => ({ id, name: `user-${id}` })
-  }
-});
+const peer = createScompPeer({ transports: [transport] });
 
-const usersSignals = createScompFragment<UsersContract>('users').implement({
-  signals: {
-    notifyLogin: async () => {
-      return;
+// Host a service
+peer.provides(
+  createScompService(Users).implement({
+    requests: {
+      getUser: async ({ id }) => ({ id, name: `user-${id}` }),
+    },
+    signals: {
+      notifyLogin: async ({ id, at }) => {
+        console.log("login", { id, at });
+      },
+    },
+    feeds: {
+      liveUsers: {
+        strategy: "fanout",
+        handler: async function* () {
+          yield { id: 1 };
+        },
+      },
+    },
+  }),
+);
+
+// Call a remote service
+const users = peer.consumes(Users);
+const user = await users.getUser({ id: 1 });
+```
+
+Rules:
+
+- `provides()` registers services. Multiple calls accumulate. Duplicate routes are a hard error.
+- `consumes()` returns a cached typed proxy. Lazily created, reused on subsequent calls.
+- A pure server only calls `provides()`. A pure client only calls `consumes()`. Bidirectional does both.
+
+### Controlled feeds
+
+Feeds can expose a typed controller for client-to-server messages scoped to an active subscription:
+
+```ts
+import type { ControlledAsyncIterable } from "@scomp/core";
+
+type PricingContract = {
+  prices(input: { symbols: string[] }): ControlledAsyncIterable<
+    { symbol: string; price: number },
+    {
+      addSymbol(input: { symbol: string }): Promise<void>;
+      getInterval(input: {}): Promise<{ intervalMs: number }>;
     }
-  }
+  >;
+};
+
+const Pricing = createContractToken<PricingContract>("pricing");
+
+// Client usage
+const pricing = peer.consumes(Pricing);
+const feed = pricing.prices({ symbols: ["AAPL"] });
+
+for await (const tick of feed) {
+  console.log(tick);
+}
+
+await feed.controller.addSymbol({ symbol: "GOOG" });
+```
+
+### Fragment composition
+
+Split service implementations across modules, then compose:
+
+```ts
+import { createScompFragment, composeScompFragments } from "@scomp/core";
+
+const usersRequests = createScompFragment(Users).implement({
+  requests: { getUser: async ({ id }) => ({ id, name: `user-${id}` }) },
 });
 
-const usersFeeds = createScompFragment<UsersContract>('users').implement({
+const usersSignals = createScompFragment(Users).implement({
+  signals: { notifyLogin: async () => {} },
+});
+
+const usersFeeds = createScompFragment(Users).implement({
   feeds: {
     liveUsers: async function* () {
       yield { id: 1 };
-    }
-  }
+    },
+  },
 });
 
-const usersRouterFragment = composeScompFragments(usersRequests, usersSignals, usersFeeds);
+const usersService = composeScompFragments(
+  usersRequests,
+  usersSignals,
+  usersFeeds,
+);
 ```
 
 Fragment composition rejects duplicate methods across fragments.
 
 ## Packages
 
-- `@scomp/client` – typed client proxy API with per-call invocation options.
-- `@scomp/core` – service/router primitives.
-- `@scomp/transport-rabbitmq` – RabbitMQ transport.
-- `@scomp/transport-browser-windows` – same-origin browser tab/window transport (SharedWorker primary, BroadcastChannel fallback).
-- `@scomp/transport-websocket-server` – WebSocket server transport for hosting routes.
-- `@scomp/transport-websocket-server-node` – Node (`ws` + `http`) WebSocket server transport.
-- `@scomp/transport-websocket-browser` – browser WebSocket client transport.
+- `@scomp/core` — contract tokens, peer, service builder, feed primitives, control plane, priority model
+- `@scomp/types` — wire protocol types, contract type utilities, security types
+- `@scomp/client` — typed client proxy (used internally by peer; direct use is legacy)
+- `@scomp/transport-rabbitmq` — RabbitMQ transport
+- `@scomp/transport-websocket-server` — Bun WebSocket server transport
+- `@scomp/transport-websocket-server-node` — Node WebSocket server transport
+- `@scomp/transport-websocket-browser` — browser WebSocket client transport
+- `@scomp/transport-websocket-client` — Node WebSocket client transport
+- `@scomp/transport-browser-windows` — same-origin browser tab/window transport (SharedWorker primary, BroadcastChannel fallback)
+- `@scomp/transport-inprocess` — in-process transport (legacy compatibility only)
+- `@scomp/transport-websocket-server-runtime` — internal shared runtime (do not import directly)
 
 ## WebSocket server package split (Bun vs Node)
 
@@ -106,111 +160,18 @@ The websocket server transport is split by runtime:
 - **Bun runtime (`Bun.serve`)**: `@scomp/transport-websocket-server`
 - **Node runtime (`ws` + `http`)**: `@scomp/transport-websocket-server-node`
 
-If you previously imported Node server transport from `@scomp/transport-websocket-server`,
-switch those imports to `@scomp/transport-websocket-server-node`.
-
 See migration notes: [docs/migration-websocket-server-split.md](docs/migration-websocket-server-split.md)
 
-## Browser transport quickstart and parity
+## Security
 
-Use `@scomp/transport-websocket-browser` in browser-like runtimes and pair it with a server transport (for example `@scomp/transport-websocket-server`) that hosts routes.
-
-```ts
-import { createScompClient, type ClientRouteHints } from "@scomp/client";
-import { createWebSocketBrowserTransport } from "@scomp/transport-websocket-browser";
-
-type ApiContract = {
-  users: {
-    getUser(input: { id: number }): Promise<{ id: number; name: string }>;
-    notifyLogin(input: { userId: number; at: string }): Promise<void>;
-    liveTicker(input: { channel: string }): AsyncIterable<{ sequence: number }>;
-  };
-};
-
-const routeHints: ClientRouteHints = {
-  "users.getUser": "request",
-  "users.notifyLogin": "signal",
-  "users.liveTicker": "feed",
-};
-
-const transport = createWebSocketBrowserTransport({
-  url: "ws://127.0.0.1:3399",
-  meta: {
-    traceId: "browser-trace",
-    tags: { source: "browser" },
-  },
-});
-
-const client = createScompClient<ApiContract>({ transport, routeHints });
-
-const user = await client.users.getUser(
-  { id: 1 },
-  {
-    meta: { tenantId: "tenant-a" },
-    priority: "P1",
-    priorityClass: "P2",
-    deadlineAtMs: Date.now() + 1_000,
-    targetLatencyMs: 40,
-  },
-);
-
-await client.users.notifyLogin({ userId: user.id, at: new Date().toISOString() });
-
-for await (const tick of client.users.liveTicker({ channel: "prices" })) {
-  console.log(tick);
-  break;
-}
-```
-
-## Browser parity guarantees
-
-`@scomp/transport-websocket-browser` now matches server/client transports for invocation envelope behavior:
-
-- `request`, `signal`, `feed_start`, and `feed_stop` all carry invocation options.
-- Metadata merge order is deterministic: `config.meta` -> `call meta` -> priority hints -> authenticated principal metadata.
-- Priority hints (`priority`, `priorityClass`, `deadlineAtMs`, `targetLatencyMs`) are serialized into envelope `meta`.
-- Feed stop uses the same metadata shape as feed start when invoked from the same call context.
-
-## Security behavior and caveats
-
-Both browser and WebSocket server transports support `security.authenticate` and `security.authorize` hooks.
-
-- Browser transport hooks run before sending outbound envelopes.
-- Server transport hooks run for inbound envelopes before route dispatch.
-- If authorization denies an operation, the operation is rejected and no outbound frame is sent (browser client behavior).
-
-Important caveats:
-
-- Browser-side hooks are best-effort client policy controls, not a trust boundary.
-- `meta.auth` is opaque and transport-agnostic; verify and enforce identity server-side.
-- Priority hints are advisory metadata unless a transport/policy explicitly enforces scheduling behavior.
-
-## Migration notes (browser websocket)
-
-If you were using browser WebSocket transport before parity updates, align to the following:
-
-1. Depend on `@scomp/transport-websocket-browser` for browser clients.
-2. Pass invocation options on client calls when needed:
-   - `meta`
-   - `priority`
-   - `priorityClass`
-   - `deadlineAtMs`
-   - `targetLatencyMs`
-3. Expect these options to be present on request/signal/feed envelopes.
-4. Keep authorization and identity enforcement on trusted server-side transports.
-
-## Demo
-
-RabbitMQ demo entrypoint (existing):
-
-- `bun run --filter='@scomp/demo' start`
-
-Browser parity demo entrypoint:
-
-- `bun run --filter='@scomp/demo' run-browser`
-
-The browser demo uses WebSocket server + browser transport in one process and showcases request/signal/feed parity including metadata, priority hints, and security hooks.
+- `meta.auth` is opaque and transport-agnostic; validate identity on the server.
+- Browser-side security hooks are client policy, not a trust boundary.
+- Control plane routes (`__scomp.*`) should be internal-only by default.
+- Priority hints are advisory metadata unless enforced by transport/policy.
 
 ## Protocol reference
 
 - [docs/transport-json-protocol.md](docs/transport-json-protocol.md)
+- [docs/adr-peer-model-v2.md](docs/adr-peer-model-v2.md) — v2 architecture decisions
+- [docs/adr-control-plane-v1.md](docs/adr-control-plane-v1.md) — control plane namespace and routes
+- [docs/adr-priority-model-v1.md](docs/adr-priority-model-v1.md) — priority classes and defaults

--- a/docs/adr-peer-model-v2.md
+++ b/docs/adr-peer-model-v2.md
@@ -1,0 +1,369 @@
+# ADR: SCOMP Peer Model and Controlled Feeds (v2)
+
+- Status: Proposed
+- Date: 2026-04-13
+
+## Context
+
+SCOMP v1 evolved organically through transport implementations (RabbitMQ, WebSocket, browser-windows) and a contract-driven service builder. The result is a working system with several architectural friction points:
+
+1. **Client/server asymmetry**: `ITransport.listen()` throws on client transports instead of being a no-op, forcing callers to know transport directionality at the call site.
+2. **No runtime contract binding**: the TypeScript contract type and the service name string are connected only by convention. Refactoring either breaks the other silently.
+3. **Feed lifecycle gaps**: feeds are server-push only. Clients cannot send structured messages back to an active feed (e.g., change parameters, pause, request snapshots) without establishing a separate RPC side-channel.
+4. **Wire protocol cruft**: four operations (`request`, `signal`, `feed_start`, `feed_stop`) when three suffice. `feed_stop` is a signal with extra context, not a distinct operation.
+5. **Error semantics**: error responses carry a freeform string. Programmatic error handling requires parsing human-readable messages.
+
+These problems compound: the asymmetric transport forces different code paths for the same logical peer, the missing contract token makes multi-version services error-prone, and the lack of feed controllers forces ad-hoc workarounds that differ per transport.
+
+This ADR proposes a coordinated set of changes to address all five problems as a single coherent design.
+
+## Decision
+
+### 1. Contract Tokens
+
+A `ContractToken<C>` binds a TypeScript contract type to a service name at runtime. It is the single source of truth for both sides of a service boundary.
+
+```typescript
+interface ContractToken<C extends object> {
+  readonly name: string;
+  readonly __contract: C; // phantom type, never read at runtime
+}
+
+function createContractToken<C extends object>(name: string): ContractToken<C>;
+```
+
+Usage:
+
+```typescript
+const TradingV1 = createContractToken<TradingContract>('trading');
+const TradingV2 = createContractToken<TradingContractV2>('trading.v2');
+
+// Server side
+peer.provides(
+  createScompService(TradingV1).implement({ ... })
+);
+
+// Client side
+const trading = peer.consumes(TradingV1);
+await trading.getPrice({ symbol: 'AAPL' });
+```
+
+Contract tokens replace the current pattern where `createScompService<Contract>('name')` takes a separate generic parameter and string argument. The token unifies both into one object.
+
+### 2. Peer Model
+
+Replace the client/server split with a symmetric `IScompPeer`. A peer is a node that can provide services (handle incoming calls) and/or consume services (make outgoing calls) over one or more transports.
+
+```typescript
+interface IScompPeer {
+  provides(...services: ServiceDefinition<object>[]): void;
+  consumes<C extends object>(token: ContractToken<C>): ScompClientProxy<C>;
+  close(): Promise<void>;
+}
+```
+
+Semantics:
+
+- `provides()` registers services this peer hosts. Multiple calls accumulate. Duplicate routes are a hard error.
+- `consumes()` returns a cached `ScompClientProxy<C>` for the given token. The proxy is lazily created on first access and reused thereafter.
+- Both are optional. A pure server only calls `provides()`. A pure client only calls `consumes()`. A bidirectional node calls both.
+- `close()` tears down all transports and feed subscriptions.
+
+```typescript
+function createScompPeer(config: { transports: IScompTransport[] }): IScompPeer;
+```
+
+### 3. Transport Interface
+
+`IScompTransport` is wire-level only. It moves bytes (or structured messages) between peers and nothing else.
+
+```typescript
+interface IScompTransport {
+  request(
+    route: string,
+    payload: unknown,
+    options?: ScompClientInvokeOptions,
+  ): Promise<unknown>;
+  signal(
+    route: string,
+    payload: unknown,
+    options?: ScompClientInvokeOptions,
+  ): Promise<void>;
+  feed(
+    route: string,
+    payload: unknown,
+    options?: ScompClientInvokeOptions,
+  ): AsyncIterable<unknown>;
+  registerRoutes(router: CompiledRouter): Promise<void> | void;
+  close(): Promise<void> | void;
+}
+```
+
+Changes from v1 `ITransport`:
+
+- `listen(router)` becomes `registerRoutes(router)`. Client-only transports implement this as a no-op instead of throwing. The name clarifies intent: you are registering route handlers, not "listening" on a port.
+- No other method changes. `request`, `signal`, `feed`, `close` remain identical.
+
+### 4. Controlled Feeds
+
+A controlled feed is a server-sent async iterable that also exposes a typed controller for client-to-server messages scoped to the active subscription.
+
+```typescript
+interface ControlledAsyncIterable<T, C> extends AsyncIterable<T> {
+  readonly controller: C;
+}
+```
+
+Controller method conventions follow the same return-type inference as contract methods:
+
+- `(input) => Promise<T>` — request (returns a value)
+- `(input) => Promise<void>` — signal (fire-and-forget)
+- Nested feeds on controllers are not supported (no `AsyncIterable` return types).
+
+Server-side creation:
+
+```typescript
+function createControlledFeed<T, C>(
+  iterable: AsyncIterable<T>,
+  controllerMethods: C,
+): ControlledAsyncIterable<T, C>;
+```
+
+Example:
+
+```typescript
+type PriceContract = {
+  prices: (input: { symbols: string[] }) => ControlledAsyncIterable<
+    PriceTick,
+    {
+      addSymbol: (input: { symbol: string }) => Promise<void>;
+      removeSymbol: (input: { symbol: string }) => Promise<void>;
+      getInterval: (input: {}) => Promise<{ intervalMs: number }>;
+    }
+  >;
+};
+
+// Client usage
+const feed = trading.prices({ symbols: ["AAPL"] });
+for await (const tick of feed) {
+  console.log(tick);
+}
+
+// Controller calls on the active feed
+await feed.controller.addSymbol({ symbol: "GOOG" });
+const { intervalMs } = await feed.controller.getInterval({});
+```
+
+#### Feed controller scoping
+
+- **Exclusive feeds** (per-subscription): each subscriber gets their own feed instance and controller. Controller state is isolated.
+- **Fanout feeds** (shared): subscribers share a feed instance. Controller calls go to the shared instance. The service author is responsible for safe concurrent access to shared controller state. Framework controller methods (`__scomp.*`) remain per-subscription even on fanout feeds.
+
+### 5. Unified Wire Protocol
+
+Reduce to three operations: `request`, `signal`, `feed`. Remove `feed_stop`.
+
+#### Envelope changes
+
+Request envelope gains optional `feed` and `method` fields:
+
+```typescript
+interface RequestEnvelope {
+  route: string; // e.g. "trading.prices"
+  op: "request" | "signal" | "feed"; // was: 'request' | 'signal' | 'feed_start' | 'feed_stop'
+  payload: unknown;
+  meta?: TransportMessageMeta;
+  feed?: string; // new: feed subscription ID (for controller calls)
+  method?: string; // new: controller method name (for controller calls)
+}
+```
+
+Response envelope gains a `code` field:
+
+```typescript
+interface ResponseEnvelope {
+  payload?: unknown;
+  error?: string;
+  code?: string; // new: structured error code
+}
+```
+
+Feed chunk envelope renames `hash` to `feed`:
+
+```typescript
+interface FeedChunkEnvelope {
+  id: string;
+  type: "next" | "done" | "error";
+  channel: "feed";
+  feed: string; // was: hash
+  payload?: unknown;
+  message?: string;
+}
+```
+
+#### Operation mapping
+
+| v1 Operation | v2 Operation                                           | Notes                   |
+| ------------ | ------------------------------------------------------ | ----------------------- |
+| `request`    | `request`                                              | Unchanged               |
+| `signal`     | `signal`                                               | Unchanged               |
+| `feed_start` | `feed`                                                 | Renamed for consistency |
+| `feed_stop`  | `signal` with `feed` + `method: '__scomp.unsubscribe'` | Collapsed into signal   |
+
+#### Controller calls on the wire
+
+Controller method calls on active feeds reuse `request` and `signal` operations with `feed` and `method` fields:
+
+```json
+{
+  "route": "trading.prices",
+  "op": "request",
+  "feed": "7d8f67a9-d3a4-e9f0-c1b2-d3e4f5a6b7c8",
+  "method": "getInterval",
+  "payload": {}
+}
+```
+
+The `feed` field identifies the subscription. The `method` field identifies the controller method. The `op` field follows the same return-type inference: `request` for methods returning a value, `signal` for void methods.
+
+Unsubscribe is a signal with a framework-reserved method:
+
+```json
+{
+  "route": "trading.prices",
+  "op": "signal",
+  "feed": "7d8f67a9-d3a4-e9f0-c1b2-d3e4f5a6b7c8",
+  "method": "__scomp.unsubscribe",
+  "payload": {}
+}
+```
+
+#### Framework-reserved controller methods
+
+All framework controller methods use the `__scomp.` prefix. This avoids collision with user-defined controller methods and is consistent with the `__scomp.*` route namespace reservation.
+
+| Method                | Op        | Purpose                                              |
+| --------------------- | --------- | ---------------------------------------------------- |
+| `__scomp.unsubscribe` | `signal`  | Tear down a feed subscription (replaces `feed_stop`) |
+| `__scomp.pause`       | `signal`  | Pause feed emission (future)                         |
+| `__scomp.resume`      | `signal`  | Resume feed emission (future)                        |
+| `__scomp.stats`       | `request` | Query feed subscription stats (future)               |
+
+Rules:
+
+- User-defined controller method names MUST NOT start with `__scomp.`.
+- Registration of a controller method starting with `__scomp.` MUST fail with a clear error.
+- Framework methods are available on all feed subscriptions regardless of the controller type declared by the service.
+
+### 6. Control Plane as Contract
+
+The existing `__scomp.*` control-plane routes (`discover`, `resolve`, `health`) become a first-class contract with a token:
+
+```typescript
+type ScompControlPlaneContract = {
+  discover: (input: {
+    servicePrefix?: string;
+    includeRoutes?: boolean;
+  }) => Promise<{
+    services: Array<{ name: string; routes?: string[] }>;
+    node: { id: string };
+  }>;
+
+  resolve: (input: {
+    route: string;
+    channel?: string;
+  }) => Promise<{
+    resolved: boolean;
+    endpoint?: { route: string; channel: string; transport?: string };
+    fallbackUsed: boolean;
+  }>;
+
+  health: (input: {
+    verbose?: boolean;
+  }) => Promise<{
+    status: "ok" | "degraded" | "down";
+    checks?: Array<{ name: string; status: string; message?: string }>;
+    node: { id: string };
+  }>;
+};
+
+const ScompControlPlane =
+  createContractToken<ScompControlPlaneContract>("__scomp");
+```
+
+The control plane is implemented and consumed like any other service:
+
+```typescript
+// Peer automatically provides the control plane
+const peer = createScompPeer({ transports: [transport] });
+
+// Any peer can consume another peer's control plane
+const cp = peer.consumes(ScompControlPlane);
+const services = await cp.discover({ includeRoutes: true });
+```
+
+### 7. Error Handling
+
+Structured error codes replace freeform error strings for programmatic handling. The `code` field is added to response envelopes.
+
+| Code                   | Meaning                                                   |
+| ---------------------- | --------------------------------------------------------- |
+| `ROUTE_NOT_FOUND`      | No handler registered for the route                       |
+| `SERVICE_NOT_FOUND`    | Service name prefix does not match any registered service |
+| `CONTROLLER_NOT_FOUND` | Controller method not found on the feed                   |
+| `FEED_NOT_FOUND`       | Feed subscription ID does not exist or has expired        |
+| `TIMEOUT`              | Operation exceeded deadline                               |
+| `UNAUTHORIZED`         | Authentication or authorization failed                    |
+
+Rules:
+
+- `code` is present on error responses, absent on success responses.
+- `error` remains as a human-readable message for logging and diagnostics.
+- Unknown codes MUST be treated as unrecoverable errors by clients.
+- Transports MUST NOT invent codes outside this set without a protocol version bump.
+
+### 8. Naming Conventions
+
+- `command` is renamed to `signal` throughout (already done on `develop`).
+- `hash` is renamed to `feed` in all envelope fields for consistency.
+- `listen()` is renamed to `registerRoutes()` on the transport interface.
+- Client-side: `consumes(token)` / Server-side: `provides(...services)`.
+
+## Migration Path
+
+### Wire protocol
+
+The `feed` operation replaces `feed_start`. Transports SHOULD accept both `feed_start` and `feed` during a transition period and emit only `feed`. `feed_stop` is replaced by `__scomp.unsubscribe` signals immediately; no dual-support period.
+
+### Transport interface
+
+`listen()` is renamed to `registerRoutes()`. The old method name can be supported as a deprecated alias during transition.
+
+### Client/server code
+
+Existing `createScompService` and `createScompClient` continue to work. `ContractToken` is additive — the builder accepts either a token or a name+generic. Migration is opt-in per service.
+
+## Compatibility Guarantees
+
+- Existing request/signal envelope shapes are unchanged.
+- Feed chunk envelopes change only the field name `hash` -> `feed`.
+- `meta` field semantics are unchanged.
+- Priority model (ADR v1) is unaffected.
+- Control-plane route names are unchanged; they gain a typed contract but the wire representation is identical.
+
+## Explicit Non-Goals (v2)
+
+- No service mesh or cross-node peer discovery (peers are connected via explicit transports).
+- No automatic contract versioning negotiation (version is encoded in the token name by convention).
+- No feed backpressure protocol changes (backpressure remains transport-level).
+- No nested feeds on controllers.
+- No transport-level multiplexing changes.
+
+## Consequences
+
+- Contract tokens eliminate the class of bugs where a service name string and generic type parameter drift apart.
+- The peer model removes the client/server transport asymmetry, making bidirectional communication a natural pattern instead of a special case.
+- Controlled feeds enable rich feed interactions without ad-hoc side channels, making patterns like parameterized subscriptions, pause/resume, and subscription stats first-class.
+- The unified wire protocol is simpler (3 ops vs 4) and extensible (controller calls reuse existing ops with scoping fields rather than introducing new operations).
+- The `__scomp.` prefix for framework controller methods is consistent with the existing route namespace reservation and provides clear collision avoidance.
+- Structured error codes enable programmatic error handling without string parsing.

--- a/docs/llms-transports.md
+++ b/docs/llms-transports.md
@@ -4,17 +4,20 @@ Companion to root `llms.txt`. This page focuses on concise setup patterns by run
 
 ## Validation gates for transport readiness
 
-- Run repository gates: `npm run lint` and `npm test`.
+- Run repository gates: `bunx turbo run lint` and `bunx turbo run test`.
 - Validate browser-windows resilience suite directly: `bun run --filter='@scomp/transport-browser-windows' test`.
-- Validate package-level lint gates directly: `bun run --filter='@scomp/transport-browser-windows' lint` plus websocket-adjacent package lint scripts.
+- Validate package-level lint gates directly: `bun run --filter='@scomp/transport-browser-windows' lint`.
 
 ## 1) Bun websocket server + browser client
 
 ```ts
-import { createScompClient, type ClientRouteHints } from "@scomp/client";
-import { createScompService } from "@scomp/core";
-import { createWebSocketBrowserTransport } from "@scomp/transport-websocket-browser";
+import {
+  createContractToken,
+  createScompPeer,
+  createScompService,
+} from "@scomp/core";
 import { createWebSocketServerTransport } from "@scomp/transport-websocket-server";
+import { createWebSocketBrowserTransport } from "@scomp/transport-websocket-browser";
 
 type Contract = {
   users: {
@@ -23,33 +26,43 @@ type Contract = {
   };
 };
 
-const users = createScompService<Contract["users"]>("users").implement({
-  requests: { get: async ({ id }) => ({ id }) },
-  signals: { ping: async () => undefined },
+const Users = createContractToken<Contract["users"]>("users");
+
+// Server peer
+const serverTransport = createWebSocketServerTransport({
+  port: 3399,
+  path: "/",
 });
+const server = createScompPeer({ transports: [serverTransport] });
 
-const server = createWebSocketServerTransport({ port: 3399, path: "/" });
-await server.listen(users.router);
+server.provides(
+  createScompService(Users).implement({
+    requests: { get: async ({ id }) => ({ id }) },
+    signals: { ping: async () => undefined },
+  }),
+);
 
-const routeHints: ClientRouteHints = {
-  "users.get": "request",
-  "users.ping": "signal",
-};
+// Client peer
+const clientTransport = createWebSocketBrowserTransport({
+  url: "ws://127.0.0.1:3399",
+});
+const client = createScompPeer({ transports: [clientTransport] });
 
-const browserTransport = createWebSocketBrowserTransport({ url: "ws://127.0.0.1:3399" });
-const client = createScompClient<Contract>({ transport: browserTransport, routeHints });
-
-await client.users.get({ id: 1 });
-await client.users.ping({ id: 1 });
+const users = client.consumes(Users);
+await users.get({ id: 1 });
+await users.ping({ id: 1 });
 ```
 
 ## 2) Node websocket server + Node websocket client
 
 ```ts
-import { createScompClient, type ClientRouteHints } from "@scomp/client";
-import { createScompService } from "@scomp/core";
-import { createWebSocketClientTransport } from "@scomp/transport-websocket-client";
+import {
+  createContractToken,
+  createScompPeer,
+  createScompService,
+} from "@scomp/core";
 import { createWebSocketServerTransport } from "@scomp/transport-websocket-server-node";
+import { createWebSocketClientTransport } from "@scomp/transport-websocket-client";
 
 type Contract = {
   math: {
@@ -57,25 +70,39 @@ type Contract = {
   };
 };
 
-const math = createScompService<Contract["math"]>("math").implement({
-  requests: { add: async ({ a, b }) => ({ sum: a + b }) },
+const Math = createContractToken<Contract["math"]>("math");
+
+// Server peer
+const serverTransport = createWebSocketServerTransport({
+  port: 3399,
+  path: "/",
 });
+const server = createScompPeer({ transports: [serverTransport] });
 
-const server = createWebSocketServerTransport({ port: 3399, path: "/" });
-await server.listen(math.router);
+server.provides(
+  createScompService(Math).implement({
+    requests: { add: async ({ a, b }) => ({ sum: a + b }) },
+  }),
+);
 
-const routeHints: ClientRouteHints = { "math.add": "request" };
-const transport = createWebSocketClientTransport({ url: "ws://127.0.0.1:3399" });
-const client = createScompClient<Contract>({ transport, routeHints });
+// Client peer
+const clientTransport = createWebSocketClientTransport({
+  url: "ws://127.0.0.1:3399",
+});
+const client = createScompPeer({ transports: [clientTransport] });
 
-await client.math.add({ a: 1, b: 2 });
+const math = client.consumes(Math);
+await math.add({ a: 1, b: 2 });
 ```
 
 ## 3) RabbitMQ transport (single process pattern)
 
 ```ts
-import { createScompClient, type ClientRouteHints } from "@scomp/client";
-import { createScompService } from "@scomp/core";
+import {
+  createContractToken,
+  createScompPeer,
+  createScompService,
+} from "@scomp/core";
 import { createRabbitMqTransport } from "@scomp/transport-rabbitmq";
 
 type Contract = {
@@ -84,24 +111,32 @@ type Contract = {
   };
 };
 
-const jobs = createScompService<Contract["jobs"]>("jobs").implement({
-  requests: { run: async () => ({ ok: true }) },
+const Jobs = createContractToken<Contract["jobs"]>("jobs");
+
+// Single peer that both provides and consumes (bidirectional)
+const transport = createRabbitMqTransport({
+  url: "amqp://guest:guest@localhost:5672",
 });
+const peer = createScompPeer({ transports: [transport] });
 
-const transport = createRabbitMqTransport({ url: "amqp://guest:guest@localhost:5672" });
-await transport.listen(jobs.router);
+peer.provides(
+  createScompService(Jobs).implement({
+    requests: { run: async () => ({ ok: true as const }) },
+  }),
+);
 
-const routeHints: ClientRouteHints = { "jobs.run": "request" };
-const client = createScompClient<Contract>({ transport, routeHints });
-
-await client.jobs.run({ id: "job-1" });
+const jobs = peer.consumes(Jobs);
+await jobs.run({ id: "job-1" });
 ```
 
 ## 4) Browser windows transport (same-origin)
 
 ```ts
-import { createScompClient, type ClientRouteHints } from "@scomp/client";
-import { createScompService } from "@scomp/core";
+import {
+  createContractToken,
+  createScompPeer,
+  createScompService,
+} from "@scomp/core";
 import { createBrowserWindowsTransport } from "@scomp/transport-browser-windows";
 
 type Contract = {
@@ -110,33 +145,104 @@ type Contract = {
   };
 };
 
-const transport = createBrowserWindowsTransport({ channelName: "scomp-app", mode: "auto" });
+const Counter = createContractToken<Contract["counter"]>("counter");
+
+const transport = createBrowserWindowsTransport({
+  channelName: "scomp-app",
+  mode: "auto",
+});
 
 // In hosting window(s)
-const counter = createScompService<Contract["counter"]>("counter").implement({
-  requests: { get: async () => ({ value: 1 }) },
-});
-await transport.listen(counter.router);
+const server = createScompPeer({ transports: [transport] });
+server.provides(
+  createScompService(Counter).implement({
+    requests: { get: async () => ({ value: 1 }) },
+  }),
+);
 
 // In invoking window(s)
-const routeHints: ClientRouteHints = { "counter.get": "request" };
-const client = createScompClient<Contract>({ transport, routeHints });
-await client.counter.get({ id: "a" });
+const client = createScompPeer({ transports: [transport] });
+const counter = client.consumes(Counter);
+await counter.get({ id: "a" });
 ```
 
-## 5) Inprocess compatibility pattern
-
-`@scomp/transport-inprocess` is for legacy/core-compatible `ScompServiceDefinition` + `ScompTransport` flow.
+## 5) Controlled feed over websocket
 
 ```ts
-import { createLegacyScompService, createScompClient as createLegacyClient } from "@scomp/core";
-import { createInprocessTransport } from "@scomp/transport-inprocess";
+import {
+  createContractToken,
+  createControlledFeed,
+  createScompPeer,
+  createScompService,
+} from "@scomp/core";
+import type { ControlledAsyncIterable } from "@scomp/core";
+import { createWebSocketServerTransport } from "@scomp/transport-websocket-server";
+import { createWebSocketBrowserTransport } from "@scomp/transport-websocket-browser";
 
-const service = createLegacyScompService()
-  .request("sum", async (a: number, b: number) => a + b)
-  .build();
+type PriceTick = { symbol: string; price: number };
 
-const transport = createInprocessTransport(service);
-const client = createLegacyClient(service, transport);
-await client.sum(1, 2);
+type PricingContract = {
+  prices(input: { symbols: string[] }): ControlledAsyncIterable<
+    PriceTick,
+    {
+      addSymbol(input: { symbol: string }): Promise<void>;
+      getInterval(input: {}): Promise<{ intervalMs: number }>;
+    }
+  >;
+};
+
+const Pricing = createContractToken<PricingContract>("pricing");
+
+// Server
+const serverTransport = createWebSocketServerTransport({
+  port: 3399,
+  path: "/",
+});
+const server = createScompPeer({ transports: [serverTransport] });
+
+server.provides(
+  createScompService(Pricing).implement({
+    feeds: {
+      prices: {
+        strategy: "exclusive",
+        handler: async function* ({ symbols }) {
+          const state = { symbols: [...symbols], intervalMs: 1000 };
+
+          return createControlledFeed(
+            (async function* () {
+              while (true) {
+                for (const symbol of state.symbols) {
+                  yield { symbol, price: Math.random() * 100 };
+                }
+                await new Promise((r) => setTimeout(r, state.intervalMs));
+              }
+            })(),
+            {
+              addSymbol: async ({ symbol }) => {
+                state.symbols.push(symbol);
+              },
+              getInterval: async () => ({ intervalMs: state.intervalMs }),
+            },
+          );
+        },
+      },
+    },
+  }),
+);
+
+// Client
+const clientTransport = createWebSocketBrowserTransport({
+  url: "ws://127.0.0.1:3399",
+});
+const client = createScompPeer({ transports: [clientTransport] });
+
+const pricing = client.consumes(Pricing);
+const feed = pricing.prices({ symbols: ["AAPL"] });
+
+await feed.controller.addSymbol({ symbol: "GOOG" });
+
+for await (const tick of feed) {
+  console.log(tick);
+  break;
+}
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -1,194 +1,463 @@
-# SCOMP LLM Guide (Contributor + Agent Quick Reference)
+# SCOMP LLM Guide (v2 Target API)
 
-This file is a practical, accuracy-first guide for using SCOMP across core APIs and transports.
+This file is the authoritative reference for using SCOMP. It describes the v2 API
+with contract tokens, the peer model, and controlled feeds.
 
 ## 1) Mental model: request / signal / feed
 
-SCOMP operations are transport-agnostic and always route by `"service.method"`:
+SCOMP has three operations. They are transport-agnostic and route by `"service.method"`:
 
-- **request**: unary request/response (`Promise<T>`)
-- **signal**: fire-and-forget side effect (`Promise<void>` from caller perspective)
-- **feed**: stream (`AsyncIterable<T>`) with explicit `feed_start` and `feed_stop` under the hood
+- **request**: unary RPC (`(input) => Promise&lt;T&gt;`)
+- **signal**: fire-and-forget side effect (`(input) => Promise&lt;void&gt;`)
+- **feed**: server-sent stream (`(input) => AsyncIterable&lt;T&gt;`) with optional typed controller
 
-If you are writing clients with `@scomp/client`, route intent must be known so calls map to the right transport operation.
+Return type determines operation kind. No annotations needed.
 
-## 2) Modern default API usage (`@scomp/core` + `@scomp/client`)
+## 2) Contract tokens
 
-Use `@scomp/core` for service/router definitions and `@scomp/client` for typed client proxies.
+A `ContractToken&lt;C&gt;` binds a TypeScript contract type to a service name at runtime.
+It is the single source of truth for both sides of a service boundary.
 
 ```ts
-import { createScompService } from "@scomp/core";
-import { createScompClient, type ClientRouteHints } from "@scomp/client";
+import { createContractToken } from "@scomp/core";
 
-type ApiContract = {
-  users: {
-    get(input: { id: number }): Promise<{ id: number; name: string }>;
-    notifyLogin(input: { id: number; at: string }): Promise<void>;
-    liveUsers(input: { room: string }): AsyncIterable<{ id: number }>;
-  };
+type TradingContract = {
+  getPrice(input: { symbol: string }): Promise<{ price: number }>;
+  notifyTrade(input: { symbol: string; qty: number }): Promise<void>;
+  prices(input: { symbols: string[] }): AsyncIterable<{ symbol: string; price: number }>;
 };
 
-const users = createScompService<ApiContract["users"]>("users").implement({
+const Trading = createContractToken<TradingContract>("trading");
+```
+
+Versioning uses separate tokens with distinct names:
+
+```ts
+const TradingV1 = createContractToken<TradingContractV1>("trading");
+const TradingV2 = createContractToken<TradingContractV2>("trading.v2");
+```
+
+Never pass a service name string and contract generic separately. Always use a token.
+
+## 3) Peer model (provides / consumes)
+
+A peer is a symmetric node that can host services and/or call remote services.
+There is no separate client/server distinction.
+
+```ts
+import { createScompPeer, createScompService } from "@scomp/core";
+
+const peer = createScompPeer({ transports: [transport] });
+
+// Host a service (incoming calls)
+peer.provides(
+  createScompService(Trading).implement({
+    requests: {
+      getPrice: async ({ symbol }) => ({ price: 42.5 }),
+    },
+    signals: {
+      notifyTrade: async ({ symbol, qty }) => {
+        console.log("trade", symbol, qty);
+      },
+    },
+    feeds: {
+      prices: async function* ({ symbols }) {
+        yield { symbol: symbols[0], price: 42.5 };
+      },
+    },
+  })
+);
+
+// Call a remote service (outgoing calls)
+const trading = peer.consumes(Trading);
+const { price } = await trading.getPrice({ symbol: "AAPL" });
+```
+
+Rules:
+- `provides()` registers services. Multiple calls accumulate. Duplicate routes are a hard error.
+- `consumes()` returns a cached typed proxy. Lazily created, reused on subsequent calls.
+- A pure server only calls `provides()`. A pure client only calls `consumes()`. Bidirectional does both.
+- `peer.close()` tears down all transports and subscriptions.
+
+## 4) Service implementation
+
+Services are implemented against a contract token using grouped or flat method definitions.
+
+### Grouped (recommended for clarity)
+
+```ts
+const service = createScompService(Trading).implement({
   requests: {
-    get: async ({ id }) => ({ id, name: `user-${id}` }),
+    getPrice: async ({ symbol }) => ({ price: 42.5 }),
   },
   signals: {
-    notifyLogin: async () => undefined,
+    notifyTrade: async ({ symbol, qty }) => {
+      console.log("trade", symbol, qty);
+    },
   },
   feeds: {
-    liveUsers: async function* () {
-      yield { id: 1 };
+    prices: async function* ({ symbols }) {
+      yield { symbol: symbols[0], price: 42.5 };
     },
   },
 });
+```
 
-const routeHints: ClientRouteHints = {
-  "users.get": "request",
-  "users.notifyLogin": "signal",
-  "users.liveUsers": "feed",
+### Flat (shorthand)
+
+```ts
+const service = createScompService(Trading).implement({
+  getPrice: async ({ symbol }) => ({ price: 42.5 }),
+  notifyTrade: { kind: "signal", handler: async ({ symbol, qty }) => { /* ... */ } },
+  prices: { kind: "feed", strategy: "fanout", handler: async function* ({ symbols }) { yield { symbol: symbols[0], price: 42.5 }; } },
+});
+```
+
+### Feed configuration options
+
+Feeds support strategy and backpressure configuration:
+
+```ts
+feeds: {
+  prices: {
+    strategy: "fanout",           // "fanout" (shared) or "exclusive" (per-subscriber)
+    hashKey: ({ symbols }) => symbols.sort().join(","),  // optional dedup key
+    backpressure: { highWaterMark: 100 },                // optional
+    handler: async function* ({ symbols }) {
+      yield { symbol: symbols[0], price: 42.5 };
+    },
+  },
+}
+```
+
+### Fragment composition
+
+Fragments allow splitting a service implementation across modules:
+
+```ts
+import { createScompFragment, composeScompFragments } from "@scomp/core";
+
+const tradingRequests = createScompFragment(Trading).implement({
+  requests: { getPrice: async ({ symbol }) => ({ price: 42.5 }) },
+});
+
+const tradingFeeds = createScompFragment(Trading).implement({
+  feeds: { prices: async function* () { yield { symbol: "AAPL", price: 42.5 }; } },
+});
+
+const tradingService = composeScompFragments(tradingRequests, tradingFeeds);
+```
+
+Duplicate methods across fragments are rejected at composition time.
+
+## 5) Controlled feeds
+
+A controlled feed extends `AsyncIterable&lt;T&gt;` with a typed `.controller` for
+client-to-server messages scoped to an active subscription.
+
+### Contract definition
+
+```ts
+import type { ControlledAsyncIterable } from "@scomp/core";
+
+type PricingContract = {
+  prices(input: { symbols: string[] }): ControlledAsyncIterable<
+    PriceTick,
+    {
+      addSymbol(input: { symbol: string }): Promise<void>;
+      removeSymbol(input: { symbol: string }): Promise<void>;
+      getInterval(input: {}): Promise<{ intervalMs: number }>;
+    }
+  >;
 };
-
-// transport is injected (websocket, rabbitmq, browser-windows, etc.)
-const client = createScompClient<ApiContract>({ transport, routeHints });
 ```
 
-## 3) Route hints are required for signal/feed in `@scomp/client`
+Controller method conventions:
+- `(input) => Promise&lt;T&gt;` — request (returns a value)
+- `(input) => Promise&lt;void&gt;` — signal (fire-and-forget)
+- No nested feeds on controllers (no `AsyncIterable` returns)
 
-Important behavior in `@scomp/client`:
-
-- Route type defaults to **`request`** when not specified.
-- Therefore `signal` and `feed` routes should be declared via `routeHints`.
-
-If you omit hints, a signal/feed route may be incorrectly invoked as request.
-
-## 4) Transport matrix and quick usage
-
-### `@scomp/transport-inprocess`
-
-- Factory: **`createInprocessTransport`**
-- Primary use: in-process calls directly against a legacy/core-compatible `ScompServiceDefinition` (`service.invoke(...)` shape).
-- Compatibility note: this transport follows legacy/core compatibility patterns (`request/observe/fireAndForget` mapping), not network wire semantics.
+### Server implementation
 
 ```ts
-import { createLegacyScompService, createScompClient as createLegacyClient } from "@scomp/core";
-import { createInprocessTransport } from "@scomp/transport-inprocess";
+import { createControlledFeed } from "@scomp/core";
 
-const service = createLegacyScompService()
-  .request("getUser", async (id: number) => ({ id }))
-  .build();
+const service = createScompService(Pricing).implement({
+  feeds: {
+    prices: async function* ({ symbols }) {
+      const state = { symbols: [...symbols], intervalMs: 1000 };
 
-const transport = createInprocessTransport(service);
-const client = createLegacyClient(service, transport);
-await client.getUser(1);
-```
-
-### `@scomp/transport-websocket-browser`
-
-- Factory: **`createWebSocketBrowserTransport`**
-- Runtime: browser-like environments (`WebSocket` available or provided via `webSocketCtor`).
-- Hosts routes? **No** (`listen()` throws). Use a server transport to host routes.
-
-```ts
-import { createWebSocketBrowserTransport } from "@scomp/transport-websocket-browser";
-
-const transport = createWebSocketBrowserTransport({
-  url: "ws://127.0.0.1:3399",
+      return createControlledFeed(
+        generatePriceTicks(state),
+        {
+          addSymbol: async ({ symbol }) => { state.symbols.push(symbol); },
+          removeSymbol: async ({ symbol }) => { state.symbols = state.symbols.filter(s => s !== symbol); },
+          getInterval: async () => ({ intervalMs: state.intervalMs }),
+        }
+      );
+    },
+  },
 });
 ```
 
-### `@scomp/transport-websocket-client`
-
-- Factory: **`createWebSocketClientTransport`**
-- Runtime: Node/client process using `ws`.
-- Hosts routes? **No** (`listen()` throws).
+### Client usage
 
 ```ts
-import { createWebSocketClientTransport } from "@scomp/transport-websocket-client";
+const pricing = peer.consumes(Pricing);
+const feed = pricing.prices({ symbols: ["AAPL"] });
 
-const transport = createWebSocketClientTransport({
-  url: "ws://127.0.0.1:3399",
-});
+// Iterate the stream
+for await (const tick of feed) {
+  console.log(tick);
+}
+
+// Controller calls on the active subscription
+await feed.controller.addSymbol({ symbol: "GOOG" });
+const { intervalMs } = await feed.controller.getInterval({});
 ```
 
-### `@scomp/transport-websocket-server` (Bun)
+### Controller scoping
 
-- Factory: **`createWebSocketServerTransport`**
-- Runtime: Bun (`Bun.serve`).
-- Use `listen(router)` to host routes.
+- **Exclusive feeds**: each subscriber gets an isolated controller instance.
+- **Fanout feeds**: subscribers share the feed. Controller calls go to the shared instance.
+  Service author is responsible for concurrent access safety.
+- Framework controller methods (`__scomp.*`) are always per-subscription, even on fanout feeds.
+
+## 6) Transport interface
+
+`IScompTransport` is wire-level only. It moves messages between peers.
 
 ```ts
+interface IScompTransport {
+  request(route: string, payload: unknown, options?: ScompClientInvokeOptions): Promise<unknown>;
+  signal(route: string, payload: unknown, options?: ScompClientInvokeOptions): Promise<void>;
+  feed(route: string, payload: unknown, options?: ScompClientInvokeOptions): AsyncIterable<unknown>;
+  registerRoutes(router: CompiledRouter): Promise<void> | void;
+  close(): Promise<void> | void;
+}
+```
+
+- `registerRoutes()` registers route handlers. Client-only transports implement this as a no-op (they never throw).
+- `request()`, `signal()`, `feed()` make outgoing calls.
+- `close()` tears down the transport.
+
+### Transport matrix
+
+| Package | Factory | Runtime | Hosts routes? |
+| --- | --- | --- | --- |
+| `@scomp/transport-websocket-server` | `createWebSocketServerTransport` | Bun (`Bun.serve`) | Yes |
+| `@scomp/transport-websocket-server-node` | `createWebSocketServerTransport` | Node (`ws` + `http`) | Yes |
+| `@scomp/transport-websocket-browser` | `createWebSocketBrowserTransport` | Browser (`WebSocket`) | No |
+| `@scomp/transport-websocket-client` | `createWebSocketClientTransport` | Node (`ws`) | No |
+| `@scomp/transport-rabbitmq` | `createRabbitMqTransport` | Node/Bun + RabbitMQ | Yes |
+| `@scomp/transport-browser-windows` | `createBrowserWindowsTransport` | Same-origin browser tabs | Yes |
+| `@scomp/transport-inprocess` | `createInprocessTransport` | Any (legacy compat only) | N/A |
+
+### Transport setup examples
+
+```ts
+// Bun WebSocket server
 import { createWebSocketServerTransport } from "@scomp/transport-websocket-server";
-
 const transport = createWebSocketServerTransport({ port: 3399, path: "/" });
-await transport.listen(router);
-```
 
-### `@scomp/transport-websocket-server-node` (Node)
-
-- Factory: **`createWebSocketServerTransport`**
-- Runtime: Node (`ws` + `http/https`).
-- Use `listen(router)` to host routes.
-
-```ts
+// Node WebSocket server
 import { createWebSocketServerTransport } from "@scomp/transport-websocket-server-node";
-
 const transport = createWebSocketServerTransport({ port: 3399, path: "/" });
-await transport.listen(router);
-```
 
-### `@scomp/transport-rabbitmq`
+// Browser WebSocket client
+import { createWebSocketBrowserTransport } from "@scomp/transport-websocket-browser";
+const transport = createWebSocketBrowserTransport({ url: "ws://127.0.0.1:3399" });
 
-- Factory: **`createRabbitMqTransport`**
-- Runtime: Node/Bun process with RabbitMQ access.
-- Can host routes with `listen(router)` and invoke via request/signal/feed.
+// Node WebSocket client
+import { createWebSocketClientTransport } from "@scomp/transport-websocket-client";
+const transport = createWebSocketClientTransport({ url: "ws://127.0.0.1:3399" });
 
-```ts
+// RabbitMQ
 import { createRabbitMqTransport } from "@scomp/transport-rabbitmq";
+const transport = createRabbitMqTransport({ url: "amqp://guest:guest@localhost:5672" });
 
-const transport = createRabbitMqTransport({
-  url: "amqp://guest:guest@localhost:5672",
-});
-await transport.listen(router);
+// Browser windows (same-origin tabs)
+import { createBrowserWindowsTransport } from "@scomp/transport-browser-windows";
+const transport = createBrowserWindowsTransport({ channelName: "scomp-app", mode: "auto" });
 ```
 
-### `@scomp/transport-browser-windows`
+## 7) Wire protocol
 
-- Factory: **`createBrowserWindowsTransport`**
-- Runtime: same-origin browser tabs/windows.
-- Broker mode: SharedWorker primary, BroadcastChannel fallback.
+Three operations on the wire: `request`, `signal`, `feed`.
+
+### Request envelope (client -> server)
+
+```json
+{
+  "route": "trading.getPrice",
+  "op": "request",
+  "payload": { "symbol": "AAPL" },
+  "meta": { "traceId": "abc-123" }
+}
+```
+
+Optional fields for controller calls on active feeds:
+
+```json
+{
+  "route": "trading.prices",
+  "op": "request",
+  "feed": "7d8f67a9-d3a4-e9f0-c1b2-d3e4f5a6b7c8",
+  "method": "getInterval",
+  "payload": {}
+}
+```
+
+- `feed`: subscription ID (present only for controller calls)
+- `method`: controller method name (present only for controller calls)
+
+### Response envelope (server -> client)
+
+Success:
+```json
+{ "payload": { "price": 42.5 } }
+```
+
+Error:
+```json
+{ "error": "Route not found: trading.getPrice", "code": "ROUTE_NOT_FOUND" }
+```
+
+### Feed chunk envelope (server -> client stream)
+
+```json
+{ "id": "req-1", "type": "next", "channel": "feed", "feed": "7d8f67a9...", "payload": { "price": 42.5 } }
+{ "id": "req-1", "type": "done", "channel": "feed", "feed": "7d8f67a9..." }
+{ "id": "req-1", "type": "error", "channel": "feed", "feed": "7d8f67a9...", "message": "Feed error" }
+```
+
+### Feed unsubscribe
+
+Unsubscribe is a signal with a framework controller method:
+
+```json
+{
+  "route": "trading.prices",
+  "op": "signal",
+  "feed": "7d8f67a9-d3a4-e9f0-c1b2-d3e4f5a6b7c8",
+  "method": "__scomp.unsubscribe",
+  "payload": {}
+}
+```
+
+### Framework-reserved controller methods
+
+All framework controller methods use the `__scomp.` prefix.
+User-defined controller methods MUST NOT start with `__scomp.`.
+
+| Method | Op | Purpose |
+| --- | --- | --- |
+| `__scomp.unsubscribe` | signal | Tear down a feed subscription |
+| `__scomp.pause` | signal | Pause feed emission (future) |
+| `__scomp.resume` | signal | Resume feed emission (future) |
+| `__scomp.stats` | request | Query feed subscription stats (future) |
+
+## 8) Control plane
+
+The control plane is a regular SCOMP service with reserved routes under `__scomp.*`.
 
 ```ts
-import { createBrowserWindowsTransport } from "@scomp/transport-browser-windows";
+import { ScompControlPlane } from "@scomp/core";
 
-const transport = createBrowserWindowsTransport({
-  channelName: "scomp-app",
-  mode: "auto",
-});
+// Every peer automatically provides the control plane.
+// Any peer can consume another peer's control plane:
+const cp = peer.consumes(ScompControlPlane);
+
+const services = await cp.discover({ includeRoutes: true });
+const endpoint = await cp.resolve({ route: "trading.getPrice" });
+const health = await cp.health({ verbose: true });
 ```
 
-## 5) Security/meta guidance and caveats
+Control plane routes:
+- `__scomp.discover` — list node-local services and routes
+- `__scomp.resolve` — resolve a callable endpoint for a route
+- `__scomp.health` — report node health status
 
-- Treat browser-side policy as **advisory**, not authoritative trust boundary.
-- Enforce identity/authorization in trusted server-side transports.
-- `meta.auth` is opaque transport metadata; validate it where trust exists.
-- Priority hints (`priority`, `priorityClass`, `deadlineAtMs`, `targetLatencyMs`) are metadata unless runtime policy enforces behavior.
-- Same-origin browser transports (`browser-windows`, browser websocket client side) are constrained by browser security model and lifecycle.
+Rules:
+- `__scomp.*` is reserved. Application routes MUST NOT use this namespace.
+- Control plane routes are privileged. Apply explicit authorization policy before external exposure.
 
-## 6) Common mistakes and correct package/import choices
+## 9) Error handling
 
-- **Mistake**: using `@scomp/core` legacy client API for modern nested route proxies.
-  - **Use**: `createScompClient` from `@scomp/client` with `routeHints`.
+Error responses carry structured codes for programmatic handling:
 
-- **Mistake**: importing Node websocket server from Bun package.
-  - **Use (Node)**: `@scomp/transport-websocket-server-node`.
-  - **Use (Bun)**: `@scomp/transport-websocket-server`.
+| Code | Meaning |
+| --- | --- |
+| `ROUTE_NOT_FOUND` | No handler registered for the route |
+| `SERVICE_NOT_FOUND` | Service name prefix has no registered service |
+| `CONTROLLER_NOT_FOUND` | Controller method not found on the feed |
+| `FEED_NOT_FOUND` | Feed subscription ID does not exist or expired |
+| `TIMEOUT` | Operation exceeded deadline |
+| `UNAUTHORIZED` | Authentication or authorization failed |
 
-- **Mistake**: trying to host routes on websocket client/browser client transports.
-  - `createWebSocketClientTransport` and `createWebSocketBrowserTransport` are client-side; they do not host routes.
+The `error` field remains as a human-readable message. The `code` field is for programmatic use.
+Unknown codes must be treated as unrecoverable.
 
-- **Mistake**: assuming `@scomp/transport-websocket-server-runtime` is the app entry package.
-  - It is an internal runtime helper package used by server transport implementations.
-  - Typical apps should import server transport factories from the Bun/Node server packages.
+## 10) Priority model
 
-- **Mistake**: omitting `routeHints` for signal/feed when using `@scomp/client`.
-  - Missing hints default to request semantics.
+Priority is advisory metadata with five classes (P0 = highest, P4 = lowest):
+
+| Class | Intent | Examples |
+| --- | --- | --- |
+| P0 | Critical control/safety | shutdown, circuit-breaker, resource protection |
+| P1 | Interactive control | health checks, discovery, session refresh |
+| P2 | Default | normal business RPC |
+| P3 | Bulk/async | telemetry, batch processing |
+| P4 | Background | backfills, prefetch, periodic tasks |
+
+Pass priority hints on client calls:
+
+```ts
+await trading.getPrice(
+  { symbol: "AAPL" },
+  { priority: "P1", deadlineAtMs: Date.now() + 1000 }
+);
+```
+
+Default operation priorities: request=P2, signal=P3, feed=P1.
+
+## 11) Security guidance
+
+- `meta.auth` is opaque. Validate identity on the server, not the client.
+- Browser-side security hooks are client policy, not a trust boundary.
+- Enforce authentication and authorization in server transports.
+- Control plane routes should be internal-only by default.
+- Same-origin browser transports are constrained by browser security model.
+
+## 12) Common mistakes
+
+- **Using a string name instead of a contract token**: always use `createContractToken&lt;C&gt;("name")`.
+- **Importing Node WS server from Bun package**: use `@scomp/transport-websocket-server-node` for Node.
+- **Trying to host routes on client transports**: browser/client transports do not host routes. Use a server transport.
+- **Using `@scomp/transport-websocket-server-runtime` directly**: it is an internal package. Import from the Bun or Node server package.
+- **Naming controller methods with `__scomp.` prefix**: this is reserved for framework methods.
+- **Nesting feeds in controller methods**: controller methods return `Promise&lt;T&gt;` or `Promise&lt;void&gt;` only. No `AsyncIterable`.
+- **Using `listen()` instead of `registerRoutes()`**: `listen()` is the v1 API. Use `registerRoutes()` or let the peer handle it.
+- **Using `createScompClient` directly instead of `peer.consumes(token)`**: the peer model handles transport wiring and proxy caching.
+
+## 13) Packages
+
+- `@scomp/core` — contract tokens, peer, service builder, feed primitives, control plane, priority model
+- `@scomp/types` — wire protocol types, contract type utilities, security types
+- `@scomp/client` — typed client proxy (used internally by peer; direct use is legacy)
+- `@scomp/transport-rabbitmq` — RabbitMQ transport
+- `@scomp/transport-websocket-server` — Bun WebSocket server transport
+- `@scomp/transport-websocket-server-node` — Node WebSocket server transport
+- `@scomp/transport-websocket-browser` — browser WebSocket client transport
+- `@scomp/transport-websocket-client` — Node WebSocket client transport
+- `@scomp/transport-browser-windows` — same-origin browser tab/window transport
+- `@scomp/transport-inprocess` — in-process transport (legacy compatibility only)
+- `@scomp/transport-websocket-server-runtime` — internal shared runtime (do not import directly)
+
+## 14) Validation commands
+
+```bash
+bunx turbo run build    # build all packages
+bunx turbo run test     # run all tests
+bunx turbo run lint     # lint all packages
+```


### PR DESCRIPTION
## Summary

- Add ADR for SCOMP v2 architecture (docs/adr-peer-model-v2.md): contract tokens, peer model, controlled feeds, unified wire protocol, structured error codes
- Update llms.txt to reflect v2 target API surface for LLM agents
- Update docs/llms-transports.md with v2 transport patterns (peer model, contract tokens)
- Update README.md for v2 API concepts and examples

## Key design decisions captured

1. Contract tokens: ContractToken binds type to runtime name
2. Peer model: symmetric provides()/consumes() replaces client/server split
3. Transport rename: registerRoutes() replaces listen()
4. Controlled feeds: ControlledAsyncIterable with typed .controller
5. Unified wire protocol: 3 ops (request/signal/feed), no more feed_start/feed_stop
6. Framework controller methods: __scomp. prefix (__scomp.unsubscribe replaces feed_stop)
7. Control plane as contract: ScompControlPlane token, auto-provided by peer
8. Structured error codes: ROUTE_NOT_FOUND, FEED_NOT_FOUND, TIMEOUT, etc.

## Notes

- These docs describe the v2 target API, not the currently implemented API
- Implementation work tracked in beads epics scomp-kad (Core v2) and scomp-zd4 (Controlled Feeds)