### PR TITLE
feat: controlled feeds — type primitives, wire protocol, framework methods, client proxy, scoping

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -7,5 +7,6 @@ export {
   type ClientRouteIntentMap,
   type CreateScompClientConfig,
   type ScompClientCallOptions,
-  type ScompClientProxy
-} from './proxy';
+  type ScompClientProxy,
+  type ScompControlledFeed,
+} from "./proxy";

--- a/packages/client/src/proxy.ts
+++ b/packages/client/src/proxy.ts
@@ -1,27 +1,58 @@
-import { ScompFeed, type ITransport, type ScompClientInvokeOptions } from '@scomp/core';
+import {
+  ScompFeed,
+  type ControlledAsyncIterable,
+  type ITransport,
+  type ScompClientInvokeOptions,
+} from "@scomp/core";
 import type {
   ContractRouteIntents,
   ScompPriorityClass,
   ScompPriorityHint,
   ScompTransportMessageMeta,
-} from '@scomp/types';
+} from "@scomp/types";
+import { createFeedHash } from "@scomp/types";
 
 type UnknownFunction = (...args: Array<unknown>) => unknown;
 
+/**
+ * Client-side representation of a controlled feed.
+ * Async-iterable for consuming values, with a `.controller` proxy for
+ * dispatching controller method calls back to the server.
+ */
+export interface ScompControlledFeed<T, C> extends AsyncIterable<T> {
+  readonly controller: C;
+}
+
+/**
+ * Extracts the controller type from a `ControlledAsyncIterable` return type.
+ * Maps each controller method to return `Promise<Awaited<ReturnType>>`.
+ */
+type ClientControllerProxy<C> = {
+  [K in keyof C]: C[K] extends (...args: infer A) => infer R
+    ? (...args: A) => Promise<Awaited<R>>
+    : never;
+};
+
 export type ScompClientProxy<Contract extends object> = {
-  [Key in keyof Contract]: Contract[Key] extends (...args: infer Args) => AsyncIterable<infer Output>
-    ? (...args: [...Args, ScompClientCallOptions?]) => ScompFeed<Output>
-    : Contract[Key] extends (...args: infer Args) => void | Promise<void>
-      ? (...args: [...Args, ScompClientCallOptions?]) => Promise<void>
-      : Contract[Key] extends (...args: infer Args) => Promise<infer Output>
-        ? (...args: [...Args, ScompClientCallOptions?]) => Promise<Output>
-        : Contract[Key] extends object
-          ? ScompClientProxy<Contract[Key]>
-          : never;
+  [Key in keyof Contract]: Contract[Key] extends (
+    ...args: infer Args
+  ) => ControlledAsyncIterable<infer Output, infer Controller>
+    ? (
+        ...args: [...Args, ScompClientCallOptions?]
+      ) => ScompControlledFeed<Output, ClientControllerProxy<Controller>>
+    : Contract[Key] extends (...args: infer Args) => AsyncIterable<infer Output>
+      ? (...args: [...Args, ScompClientCallOptions?]) => ScompFeed<Output>
+      : Contract[Key] extends (...args: infer Args) => void | Promise<void>
+        ? (...args: [...Args, ScompClientCallOptions?]) => Promise<void>
+        : Contract[Key] extends (...args: infer Args) => Promise<infer Output>
+          ? (...args: [...Args, ScompClientCallOptions?]) => Promise<Output>
+          : Contract[Key] extends object
+            ? ScompClientProxy<Contract[Key]>
+            : never;
 };
 
 export interface ClientRouteHints {
-  [route: string]: 'request' | 'signal' | 'feed';
+  [route: string]: "request" | "signal" | "feed";
 }
 
 export interface CreateScompClientConfig {
@@ -54,7 +85,7 @@ export interface ClientRouteOptions {
 export type ClientRouteOptionResolver = (context: {
   route: string;
   payload: unknown;
-  operation: 'request' | 'signal' | 'feed';
+  operation: "request" | "signal" | "feed";
 }) => ClientRouteOptionEntry | undefined;
 
 interface ResolvedInvocation {
@@ -63,10 +94,12 @@ interface ResolvedInvocation {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === "object" && value !== null;
 }
 
-function normalizeRouteEntry(entry?: ClientRouteOptionEntry): ScompClientInvokeOptions | undefined {
+function normalizeRouteEntry(
+  entry?: ClientRouteOptionEntry,
+): ScompClientInvokeOptions | undefined {
   if (!entry) {
     return undefined;
   }
@@ -119,7 +152,9 @@ function mergeOptions(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-function toInvokeOptions(callOptions?: ScompClientCallOptions): ScompClientInvokeOptions | undefined {
+function toInvokeOptions(
+  callOptions?: ScompClientCallOptions,
+): ScompClientInvokeOptions | undefined {
   if (!callOptions) {
     return undefined;
   }
@@ -148,7 +183,7 @@ function resolveInvocation(
   route: string,
   payload: unknown,
   callOptionsRaw: unknown,
-  operation: 'request' | 'signal' | 'feed',
+  operation: "request" | "signal" | "feed",
   routeOptions: ClientRouteOptions | undefined,
   routeOptionResolver: ClientRouteOptionResolver | undefined,
 ): ResolvedInvocation {
@@ -166,12 +201,69 @@ function resolveInvocation(
 
   return {
     payload,
-    options: mergeOptions(mergeOptions(routeDefault, resolvedByResolver), callOptions),
+    options: mergeOptions(
+      mergeOptions(routeDefault, resolvedByResolver),
+      callOptions,
+    ),
   };
 }
 
-function getRouteType(route: string, routeHints?: ClientRouteHints): 'request' | 'signal' | 'feed' {
-  return routeHints?.[route] ?? 'request';
+function getRouteType(
+  route: string,
+  routeHints?: ClientRouteHints,
+): "request" | "signal" | "feed" {
+  return routeHints?.[route] ?? "request";
+}
+
+/**
+ * Creates a JS Proxy that intercepts property access and dispatches
+ * controller method calls as transport requests scoped to a feed.
+ */
+function createControllerProxy(
+  transport: ITransport,
+  route: string,
+  feedId: string,
+): unknown {
+  return new Proxy(Object.create(null) as Record<string, unknown>, {
+    get(_target, prop) {
+      if (typeof prop !== "string") {
+        return undefined;
+      }
+
+      return (payload: unknown) => {
+        return transport.request(route, payload, {
+          feed: feedId,
+          method: prop,
+        });
+      };
+    },
+  });
+}
+
+/**
+ * Wraps a transport feed async iterable with a controller proxy,
+ * producing a {@link ScompControlledFeed}.
+ */
+function createControlledScompFeed(
+  transport: ITransport,
+  route: string,
+  payload: unknown,
+  options: ScompClientInvokeOptions | undefined,
+): ScompControlledFeed<unknown, unknown> {
+  const feedId = createFeedHash(route, payload);
+  const feed = new ScompFeed(async function* feedGenerator() {
+    for await (const chunk of transport.feed(route, payload, options)) {
+      yield chunk;
+    }
+  });
+  const controller = createControllerProxy(transport, route, feedId);
+
+  return {
+    [Symbol.asyncIterator]() {
+      return feed[Symbol.asyncIterator]();
+    },
+    controller,
+  };
 }
 
 function createProxyNode(
@@ -179,7 +271,7 @@ function createProxyNode(
   routeHints: ClientRouteHints | undefined,
   routeOptions: ClientRouteOptions | undefined,
   routeOptionResolver: ClientRouteOptionResolver | undefined,
-  segments: Array<string>
+  segments: Array<string>,
 ): UnknownFunction {
   const target = () => {
     return undefined;
@@ -187,7 +279,7 @@ function createProxyNode(
 
   return new Proxy(target, {
     get(_target, prop, _receiver) {
-      if (typeof prop !== 'string') {
+      if (typeof prop !== "string") {
         return undefined;
       }
 
@@ -200,7 +292,7 @@ function createProxyNode(
       );
     },
     apply(_target, _thisArg, argArray: Array<unknown>) {
-      const route = segments.join('.');
+      const route = segments.join(".");
       const routeType = getRouteType(route, routeHints);
       const invocation = resolveInvocation(
         route,
@@ -211,25 +303,26 @@ function createProxyNode(
         routeOptionResolver,
       );
 
-      if (routeType === 'signal') {
+      if (routeType === "signal") {
         return transport.signal(route, invocation.payload, invocation.options);
       }
 
-      if (routeType === 'feed') {
-        return new ScompFeed(async function* feedGenerator() {
-          for await (const chunk of transport.feed(route, invocation.payload, invocation.options)) {
-            yield chunk;
-          }
-        });
+      if (routeType === "feed") {
+        return createControlledScompFeed(
+          transport,
+          route,
+          invocation.payload,
+          invocation.options,
+        );
       }
 
       return transport.request(route, invocation.payload, invocation.options);
-    }
+    },
   });
 }
 
 export function createScompClient<Contract extends object>(
-  config: CreateScompClientConfig
+  config: CreateScompClientConfig,
 ): ScompClientProxy<Contract> {
   return createProxyNode(
     config.transport,
@@ -240,4 +333,5 @@ export function createScompClient<Contract extends object>(
   ) as unknown as ScompClientProxy<Contract>;
 }
 
-export type ClientRouteIntentMap<Contract extends object> = ContractRouteIntents<Contract>;
+export type ClientRouteIntentMap<Contract extends object> =
+  ContractRouteIntents<Contract>;

--- a/packages/core/src/builder-types.ts
+++ b/packages/core/src/builder-types.ts
@@ -1,0 +1,332 @@
+import type {
+  AnyContractMethod,
+  ContractNetworkIntent,
+  ContractMethodInput,
+} from "@scomp/types";
+
+type RouteKind = "request" | "signal" | "feed";
+
+export interface RequestImplementationConfig<Input, Output> {
+  kind?: "request";
+  parser?: (payload: unknown) => Input;
+  handler: (input: Input) => Promise<Output>;
+}
+
+export interface SignalImplementationConfig<Input> {
+  kind: "signal";
+  parser?: (payload: unknown) => Input;
+  handler: (input: Input) => void | Promise<void>;
+}
+
+export interface FeedImplementationConfig<Input, Output> {
+  kind?: "feed";
+  parser?: (payload: unknown) => Input;
+  strategy: "fanout" | "exclusive";
+  hashKey?: (input: Input) => string;
+  backpressure?: {
+    highWaterMark?: number;
+  };
+  handler: (input: Input) => AsyncIterable<Output>;
+}
+
+type ContractMethodKeys<Contract extends object> = {
+  [MethodName in keyof Contract]: Contract[MethodName] extends AnyContractMethod
+    ? MethodName
+    : never;
+}[keyof Contract];
+
+type RequestRawHandler<Method> = Method extends (
+  input: infer Input,
+) => Promise<infer Output>
+  ? (input: Input) => Promise<Output>
+  : never;
+
+type SignalRawHandler<Method> = Method extends (
+  input: infer Input,
+) => void | Promise<void>
+  ? (input: Input) => void | Promise<void>
+  : never;
+
+type FeedRawHandler<Method> = Method extends (
+  input: infer Input,
+) => AsyncIterable<infer Output>
+  ? (input: Input) => AsyncIterable<Output>
+  : never;
+
+type MethodKind<Method extends AnyContractMethod> =
+  ReturnType<Method> extends AsyncIterable<unknown>
+    ? "feed"
+    : ReturnType<Method> extends void | Promise<void>
+      ? "signal"
+      : ReturnType<Method> extends Promise<unknown>
+        ? "request"
+        : never;
+
+type RequestMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends "request"
+    ?
+        | RequestRawHandler<Method>
+        | RequestImplementationConfig<
+            ContractMethodInput<Method>,
+            Awaited<ReturnType<Method>>
+          >
+    : never;
+
+type SignalMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends "signal"
+    ?
+        | SignalRawHandler<Method>
+        | SignalImplementationConfig<ContractMethodInput<Method>>
+    : never;
+
+type FeedMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends "feed"
+    ?
+        | FeedRawHandler<Method>
+        | FeedImplementationConfig<
+            ContractMethodInput<Method>,
+            ReturnType<Method> extends AsyncIterable<infer Output>
+              ? Output
+              : never
+          >
+    : never;
+
+type GroupedRequestImplementationConfig<Input, Output> = Omit<
+  RequestImplementationConfig<Input, Output>,
+  "kind"
+>;
+type GroupedSignalImplementationConfig<Input> = Omit<
+  SignalImplementationConfig<Input>,
+  "kind"
+>;
+type GroupedFeedImplementationConfig<Input, Output> = Omit<
+  FeedImplementationConfig<Input, Output>,
+  "kind"
+>;
+
+type GroupedRequestMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends "request"
+    ?
+        | RequestRawHandler<Method>
+        | GroupedRequestImplementationConfig<
+            ContractMethodInput<Method>,
+            Awaited<ReturnType<Method>>
+          >
+    : never;
+
+type GroupedSignalMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends "signal"
+    ?
+        | SignalRawHandler<Method>
+        | GroupedSignalImplementationConfig<ContractMethodInput<Method>>
+    : never;
+
+type GroupedFeedMethodImplementation<Method extends AnyContractMethod> =
+  MethodKind<Method> extends "feed"
+    ?
+        | FeedRawHandler<Method>
+        | GroupedFeedImplementationConfig<
+            ContractMethodInput<Method>,
+            ReturnType<Method> extends AsyncIterable<infer Output>
+              ? Output
+              : never
+          >
+    : never;
+
+type ContractMethodKeysByKind<
+  Contract extends object,
+  Kind extends RouteKind,
+> = {
+  [MethodName in ContractMethodKeys<Contract>]: MethodKind<
+    Extract<Contract[MethodName], AnyContractMethod>
+  > extends Kind
+    ? MethodName
+    : never;
+}[ContractMethodKeys<Contract>];
+
+export type GroupedMethodImplementations<
+  Contract extends object,
+  Kind extends RouteKind,
+> = {
+  [MethodName in ContractMethodKeysByKind<
+    Contract,
+    Kind
+  >]: Kind extends "request"
+    ? GroupedRequestMethodImplementation<
+        Extract<Contract[MethodName], AnyContractMethod>
+      >
+    : Kind extends "signal"
+      ? GroupedSignalMethodImplementation<
+          Extract<Contract[MethodName], AnyContractMethod>
+        >
+      : GroupedFeedMethodImplementation<
+          Extract<Contract[MethodName], AnyContractMethod>
+        >;
+};
+
+type MethodImplementation<Method extends AnyContractMethod> =
+  | RequestMethodImplementation<Method>
+  | SignalMethodImplementation<Method>
+  | FeedMethodImplementation<Method>;
+
+export type ServiceMethodImplementations<Contract extends object> = {
+  [MethodName in ContractMethodKeys<Contract>]: MethodImplementation<
+    Extract<Contract[MethodName], AnyContractMethod>
+  >;
+};
+
+export type FragmentMethodImplementations<Contract extends object> = Partial<
+  ServiceMethodImplementations<Contract>
+>;
+
+type FlatServiceMethodImplementationsInput<Contract extends object> = Partial<
+  ServiceMethodImplementations<Contract>
+>;
+
+export interface GroupedServiceMethodImplementations<Contract extends object> {
+  requests: GroupedMethodImplementations<Contract, "request">;
+  signals: GroupedMethodImplementations<Contract, "signal">;
+  feeds: GroupedMethodImplementations<Contract, "feed">;
+}
+
+/**
+ * Partial grouped method implementations used by both services and fragments.
+ *
+ * Previously `GroupedServiceMethodImplementationsInput` and
+ * `GroupedMethodImplementationsInput` were separate but structurally identical
+ * types. They have been unified into this single interface.
+ */
+export interface GroupedMethodImplementationsInput<Contract extends object> {
+  requests?: Partial<GroupedMethodImplementations<Contract, "request">>;
+  signals?: Partial<GroupedMethodImplementations<Contract, "signal">>;
+  feeds?: Partial<GroupedMethodImplementations<Contract, "feed">>;
+}
+
+export interface GroupedFragmentMethodImplementations<
+  Contract extends object,
+> extends GroupedMethodImplementationsInput<Contract> {}
+
+export type ServiceMethodImplementationsInput<Contract extends object> =
+  | FlatServiceMethodImplementationsInput<Contract>
+  | GroupedMethodImplementationsInput<Contract>;
+
+type GroupedProvidedMethodKeys<Grouped> = Grouped extends {
+  requests?: infer Requests;
+  signals?: infer Signals;
+  feeds?: infer Feeds;
+}
+  ?
+      | keyof NonNullable<Requests>
+      | keyof NonNullable<Signals>
+      | keyof NonNullable<Feeds>
+  : never;
+
+export type ProvidedMethodKeys<Methods> = Methods extends {
+  requests?: unknown;
+  signals?: unknown;
+  feeds?: unknown;
+}
+  ? GroupedProvidedMethodKeys<Methods>
+  : keyof Methods;
+
+type MissingServiceMethodKeys<Contract extends object, Methods> = Exclude<
+  ContractMethodKeys<Contract>,
+  ProvidedMethodKeys<Methods>
+>;
+
+type UnknownServiceMethodKeys<Contract extends object, Methods> = Exclude<
+  ProvidedMethodKeys<Methods>,
+  ContractMethodKeys<Contract>
+>;
+
+type EnsureKnownServiceMethods<Contract extends object, Methods> = [
+  UnknownServiceMethodKeys<Contract, Methods>,
+] extends [never]
+  ? {}
+  : {
+      __scomp_unknown_methods__: {
+        [MethodName in UnknownServiceMethodKeys<
+          Contract,
+          Methods
+        >]: "Method is not in contract";
+      };
+    };
+
+type EnsureCompleteServiceImplementation<Contract extends object, Methods> = [
+  MissingServiceMethodKeys<Contract, Methods>,
+] extends [never]
+  ? {}
+  : {
+      __scomp_missing_methods__: {
+        [MethodName in MissingServiceMethodKeys<
+          Contract,
+          Methods
+        >]: "Missing contract implementation";
+      };
+    };
+
+export type StrictServiceImplementationChecks<
+  Contract extends object,
+  Methods,
+> = EnsureKnownServiceMethods<Contract, Methods> &
+  EnsureCompleteServiceImplementation<Contract, Methods>;
+
+export interface CompiledRoute {
+  route: string;
+  kind: RouteKind;
+  parser?: (payload: unknown) => unknown;
+  strategy?: "fanout" | "exclusive";
+  hashKey?: (payload: unknown) => string;
+  backpressure?: {
+    highWaterMark?: number;
+  };
+  handler: (payload: unknown) => unknown;
+}
+
+export type CompiledRouter = Record<string, CompiledRoute>;
+
+export interface ServiceDefinition<Contract extends object> {
+  name: string;
+  networkIntent: ContractNetworkIntent<Contract>;
+  router: CompiledRouter;
+}
+
+export interface FragmentDefinition<
+  Contract extends object,
+  Methods extends string = never,
+> {
+  name: string;
+  networkIntent: Partial<ContractNetworkIntent<Contract>>;
+  router: CompiledRouter;
+  readonly __scomp_fragment_methods__?: Methods;
+}
+
+export type FragmentMethodNames<Fragment> =
+  Fragment extends FragmentDefinition<object, infer Methods> ? Methods : never;
+
+export type CombinedFragmentMethodNames<Fragments extends readonly unknown[]> =
+  Fragments extends readonly [infer Fragment, ...infer Rest]
+    ? FragmentMethodNames<Fragment> | CombinedFragmentMethodNames<Rest>
+    : never;
+
+type DuplicateFragmentMethodNames<
+  Fragments extends readonly unknown[],
+  Seen extends string = never,
+  Duplicates extends string = never,
+> = Fragments extends readonly [infer Fragment, ...infer Rest]
+  ? DuplicateFragmentMethodNames<
+      Rest,
+      Seen | FragmentMethodNames<Fragment>,
+      Duplicates | Extract<FragmentMethodNames<Fragment>, Seen>
+    >
+  : Duplicates;
+
+export type EnsureNoDuplicateFragmentMethods<
+  Fragments extends readonly unknown[],
+> = [DuplicateFragmentMethodNames<Fragments>] extends [never]
+  ? {}
+  : {
+      __scomp_duplicate_fragment_methods__: {
+        [MethodName in DuplicateFragmentMethodNames<Fragments>]: "Duplicate method declared across fragments";
+      };
+    };

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -1,335 +1,36 @@
-import type {
-  AnyContractMethod,
-  ContractNetworkIntent,
-  ContractMethodInput,
-} from "@scomp/types";
+import type { ContractNetworkIntent } from "@scomp/types";
 import type { ContractToken } from "./contract-token";
+import type {
+  CombinedFragmentMethodNames,
+  CompiledRoute,
+  CompiledRouter,
+  EnsureNoDuplicateFragmentMethods,
+  FragmentDefinition,
+  FragmentMethodImplementations,
+  GroupedFragmentMethodImplementations,
+  GroupedMethodImplementationsInput,
+  GroupedServiceMethodImplementations,
+  ProvidedMethodKeys,
+  ServiceDefinition,
+  ServiceMethodImplementationsInput,
+  StrictServiceImplementationChecks,
+} from "./builder-types";
+
+export type {
+  CompiledRoute,
+  CompiledRouter,
+  FeedImplementationConfig,
+  FragmentDefinition,
+  FragmentMethodImplementations,
+  GroupedFragmentMethodImplementations,
+  GroupedServiceMethodImplementations,
+  RequestImplementationConfig,
+  ServiceDefinition,
+  ServiceMethodImplementations,
+  SignalImplementationConfig,
+} from "./builder-types";
 
 type RouteKind = "request" | "signal" | "feed";
-
-export interface RequestImplementationConfig<Input, Output> {
-  kind?: "request";
-  parser?: (payload: unknown) => Input;
-  handler: (input: Input) => Promise<Output>;
-}
-
-export interface SignalImplementationConfig<Input> {
-  kind: "signal";
-  parser?: (payload: unknown) => Input;
-  handler: (input: Input) => void | Promise<void>;
-}
-
-export interface FeedImplementationConfig<Input, Output> {
-  kind?: "feed";
-  parser?: (payload: unknown) => Input;
-  strategy: "fanout" | "exclusive";
-  hashKey?: (input: Input) => string;
-  backpressure?: {
-    highWaterMark?: number;
-  };
-  handler: (input: Input) => AsyncIterable<Output>;
-}
-
-type ContractMethodKeys<Contract extends object> = {
-  [MethodName in keyof Contract]: Contract[MethodName] extends AnyContractMethod
-    ? MethodName
-    : never;
-}[keyof Contract];
-
-type RequestRawHandler<Method> = Method extends (
-  input: infer Input,
-) => Promise<infer Output>
-  ? (input: Input) => Promise<Output>
-  : never;
-
-type SignalRawHandler<Method> = Method extends (
-  input: infer Input,
-) => void | Promise<void>
-  ? (input: Input) => void | Promise<void>
-  : never;
-
-type FeedRawHandler<Method> = Method extends (
-  input: infer Input,
-) => AsyncIterable<infer Output>
-  ? (input: Input) => AsyncIterable<Output>
-  : never;
-
-type MethodKind<Method extends AnyContractMethod> =
-  ReturnType<Method> extends AsyncIterable<unknown>
-    ? "feed"
-    : ReturnType<Method> extends void | Promise<void>
-      ? "signal"
-      : ReturnType<Method> extends Promise<unknown>
-        ? "request"
-        : never;
-
-type RequestMethodImplementation<Method extends AnyContractMethod> =
-  MethodKind<Method> extends "request"
-    ?
-        | RequestRawHandler<Method>
-        | RequestImplementationConfig<
-            ContractMethodInput<Method>,
-            Awaited<ReturnType<Method>>
-          >
-    : never;
-
-type SignalMethodImplementation<Method extends AnyContractMethod> =
-  MethodKind<Method> extends "signal"
-    ?
-        | SignalRawHandler<Method>
-        | SignalImplementationConfig<ContractMethodInput<Method>>
-    : never;
-
-type FeedMethodImplementation<Method extends AnyContractMethod> =
-  MethodKind<Method> extends "feed"
-    ?
-        | FeedRawHandler<Method>
-        | FeedImplementationConfig<
-            ContractMethodInput<Method>,
-            ReturnType<Method> extends AsyncIterable<infer Output>
-              ? Output
-              : never
-          >
-    : never;
-
-type GroupedRequestImplementationConfig<Input, Output> = Omit<
-  RequestImplementationConfig<Input, Output>,
-  "kind"
->;
-type GroupedSignalImplementationConfig<Input> = Omit<
-  SignalImplementationConfig<Input>,
-  "kind"
->;
-type GroupedFeedImplementationConfig<Input, Output> = Omit<
-  FeedImplementationConfig<Input, Output>,
-  "kind"
->;
-
-type GroupedRequestMethodImplementation<Method extends AnyContractMethod> =
-  MethodKind<Method> extends "request"
-    ?
-        | RequestRawHandler<Method>
-        | GroupedRequestImplementationConfig<
-            ContractMethodInput<Method>,
-            Awaited<ReturnType<Method>>
-          >
-    : never;
-
-type GroupedSignalMethodImplementation<Method extends AnyContractMethod> =
-  MethodKind<Method> extends "signal"
-    ?
-        | SignalRawHandler<Method>
-        | GroupedSignalImplementationConfig<ContractMethodInput<Method>>
-    : never;
-
-type GroupedFeedMethodImplementation<Method extends AnyContractMethod> =
-  MethodKind<Method> extends "feed"
-    ?
-        | FeedRawHandler<Method>
-        | GroupedFeedImplementationConfig<
-            ContractMethodInput<Method>,
-            ReturnType<Method> extends AsyncIterable<infer Output>
-              ? Output
-              : never
-          >
-    : never;
-
-type ContractMethodKeysByKind<
-  Contract extends object,
-  Kind extends RouteKind,
-> = {
-  [MethodName in ContractMethodKeys<Contract>]: MethodKind<
-    Extract<Contract[MethodName], AnyContractMethod>
-  > extends Kind
-    ? MethodName
-    : never;
-}[ContractMethodKeys<Contract>];
-
-type GroupedMethodImplementations<
-  Contract extends object,
-  Kind extends RouteKind,
-> = {
-  [MethodName in ContractMethodKeysByKind<
-    Contract,
-    Kind
-  >]: Kind extends "request"
-    ? GroupedRequestMethodImplementation<
-        Extract<Contract[MethodName], AnyContractMethod>
-      >
-    : Kind extends "signal"
-      ? GroupedSignalMethodImplementation<
-          Extract<Contract[MethodName], AnyContractMethod>
-        >
-      : GroupedFeedMethodImplementation<
-          Extract<Contract[MethodName], AnyContractMethod>
-        >;
-};
-
-type MethodImplementation<Method extends AnyContractMethod> =
-  | RequestMethodImplementation<Method>
-  | SignalMethodImplementation<Method>
-  | FeedMethodImplementation<Method>;
-
-export type ServiceMethodImplementations<Contract extends object> = {
-  [MethodName in ContractMethodKeys<Contract>]: MethodImplementation<
-    Extract<Contract[MethodName], AnyContractMethod>
-  >;
-};
-
-export type FragmentMethodImplementations<Contract extends object> = Partial<
-  ServiceMethodImplementations<Contract>
->;
-
-type FlatServiceMethodImplementationsInput<Contract extends object> = Partial<
-  ServiceMethodImplementations<Contract>
->;
-
-export interface GroupedServiceMethodImplementations<Contract extends object> {
-  requests: GroupedMethodImplementations<Contract, "request">;
-  signals: GroupedMethodImplementations<Contract, "signal">;
-  feeds: GroupedMethodImplementations<Contract, "feed">;
-}
-
-interface GroupedServiceMethodImplementationsInput<Contract extends object> {
-  requests?: Partial<GroupedMethodImplementations<Contract, "request">>;
-  signals?: Partial<GroupedMethodImplementations<Contract, "signal">>;
-  feeds?: Partial<GroupedMethodImplementations<Contract, "feed">>;
-}
-
-type GroupedMethodImplementationsInput<Contract extends object> = {
-  requests?: Partial<GroupedMethodImplementations<Contract, "request">>;
-  signals?: Partial<GroupedMethodImplementations<Contract, "signal">>;
-  feeds?: Partial<GroupedMethodImplementations<Contract, "feed">>;
-};
-
-export interface GroupedFragmentMethodImplementations<
-  Contract extends object,
-> extends GroupedMethodImplementationsInput<Contract> {}
-
-type ServiceMethodImplementationsInput<Contract extends object> =
-  | FlatServiceMethodImplementationsInput<Contract>
-  | GroupedServiceMethodImplementationsInput<Contract>;
-
-type GroupedProvidedMethodKeys<Grouped> = Grouped extends {
-  requests?: infer Requests;
-  signals?: infer Signals;
-  feeds?: infer Feeds;
-}
-  ?
-      | keyof NonNullable<Requests>
-      | keyof NonNullable<Signals>
-      | keyof NonNullable<Feeds>
-  : never;
-
-type ProvidedMethodKeys<Methods> = Methods extends {
-  requests?: unknown;
-  signals?: unknown;
-  feeds?: unknown;
-}
-  ? GroupedProvidedMethodKeys<Methods>
-  : keyof Methods;
-
-type MissingServiceMethodKeys<Contract extends object, Methods> = Exclude<
-  ContractMethodKeys<Contract>,
-  ProvidedMethodKeys<Methods>
->;
-
-type UnknownServiceMethodKeys<Contract extends object, Methods> = Exclude<
-  ProvidedMethodKeys<Methods>,
-  ContractMethodKeys<Contract>
->;
-
-type EnsureKnownServiceMethods<Contract extends object, Methods> = [
-  UnknownServiceMethodKeys<Contract, Methods>,
-] extends [never]
-  ? {}
-  : {
-      __scomp_unknown_methods__: {
-        [MethodName in UnknownServiceMethodKeys<
-          Contract,
-          Methods
-        >]: "Method is not in contract";
-      };
-    };
-
-type EnsureCompleteServiceImplementation<Contract extends object, Methods> = [
-  MissingServiceMethodKeys<Contract, Methods>,
-] extends [never]
-  ? {}
-  : {
-      __scomp_missing_methods__: {
-        [MethodName in MissingServiceMethodKeys<
-          Contract,
-          Methods
-        >]: "Missing contract implementation";
-      };
-    };
-
-type StrictServiceImplementationChecks<
-  Contract extends object,
-  Methods,
-> = EnsureKnownServiceMethods<Contract, Methods> &
-  EnsureCompleteServiceImplementation<Contract, Methods>;
-
-export interface CompiledRoute {
-  route: string;
-  kind: RouteKind;
-  parser?: (payload: unknown) => unknown;
-  strategy?: "fanout" | "exclusive";
-  hashKey?: (payload: unknown) => string;
-  backpressure?: {
-    highWaterMark?: number;
-  };
-  handler: (payload: unknown) => unknown;
-}
-
-export type CompiledRouter = Record<string, CompiledRoute>;
-
-export interface ServiceDefinition<Contract extends object> {
-  name: string;
-  networkIntent: ContractNetworkIntent<Contract>;
-  router: CompiledRouter;
-}
-
-export interface FragmentDefinition<
-  Contract extends object,
-  Methods extends string = never,
-> {
-  name: string;
-  networkIntent: Partial<ContractNetworkIntent<Contract>>;
-  router: CompiledRouter;
-  readonly __scomp_fragment_methods__?: Methods;
-}
-
-type FragmentMethodNames<Fragment> =
-  Fragment extends FragmentDefinition<object, infer Methods> ? Methods : never;
-
-type CombinedFragmentMethodNames<Fragments extends readonly unknown[]> =
-  Fragments extends readonly [infer Fragment, ...infer Rest]
-    ? FragmentMethodNames<Fragment> | CombinedFragmentMethodNames<Rest>
-    : never;
-
-type DuplicateFragmentMethodNames<
-  Fragments extends readonly unknown[],
-  Seen extends string = never,
-  Duplicates extends string = never,
-> = Fragments extends readonly [infer Fragment, ...infer Rest]
-  ? DuplicateFragmentMethodNames<
-      Rest,
-      Seen | FragmentMethodNames<Fragment>,
-      Duplicates | Extract<FragmentMethodNames<Fragment>, Seen>
-    >
-  : Duplicates;
-
-type EnsureNoDuplicateFragmentMethods<Fragments extends readonly unknown[]> = [
-  DuplicateFragmentMethodNames<Fragments>,
-] extends [never]
-  ? {}
-  : {
-      __scomp_duplicate_fragment_methods__: {
-        [MethodName in DuplicateFragmentMethodNames<Fragments>]: "Duplicate method declared across fragments";
-      };
-    };
 
 function normalizeMethodConfig(
   methodConfig: unknown,
@@ -445,7 +146,7 @@ function compileGroupedRouter<Contract extends object>(
   name: string,
   groupedMethods:
     | GroupedServiceMethodImplementations<Contract>
-    | GroupedServiceMethodImplementationsInput<Contract>
+    | GroupedMethodImplementationsInput<Contract>
     | GroupedFragmentMethodImplementations<Contract>,
 ): CompiledRouter {
   const router: CompiledRouter = {};

--- a/packages/core/src/controlled-feed.ts
+++ b/packages/core/src/controlled-feed.ts
@@ -1,0 +1,51 @@
+export interface ControlledFeedOptions {
+  /**
+   * Feed scoping mode.
+   * - `'exclusive'`: Each subscriber gets its own controller instance (default).
+   * - `'fanout'`: Subscribers share a single controller instance.
+   */
+  scope?: "exclusive" | "fanout";
+}
+
+/**
+ * An async iterable that also exposes a typed controller for
+ * client-to-server messages scoped to an active feed subscription.
+ */
+export interface ControlledAsyncIterable<
+  T,
+  C = unknown,
+> extends AsyncIterable<T> {
+  readonly controller: C;
+  /** @internal Feed scoping mode for the runtime. */
+  readonly __scope?: "exclusive" | "fanout";
+}
+
+/**
+ * Creates a controlled feed by combining an async iterable with controller methods.
+ *
+ * @param iterable - The server-push async iterable
+ * @param controllerMethods - Object whose methods are callable by the client on this feed
+ * @param options - Optional feed configuration
+ * @throws If any controller method name starts with '__scomp.' (reserved prefix)
+ */
+export function createControlledFeed<T, C extends object>(
+  iterable: AsyncIterable<T>,
+  controllerMethods: C,
+  options?: ControlledFeedOptions,
+): ControlledAsyncIterable<T, C> {
+  for (const key of Object.keys(controllerMethods)) {
+    if (key.startsWith("__scomp.")) {
+      throw new Error(
+        `Controller method "${key}" uses reserved __scomp. prefix.`,
+      );
+    }
+  }
+
+  return {
+    [Symbol.asyncIterator]() {
+      return iterable[Symbol.asyncIterator]();
+    },
+    controller: controllerMethods,
+    __scope: options?.scope ?? "exclusive",
+  };
+}

--- a/packages/core/src/framework-methods.ts
+++ b/packages/core/src/framework-methods.ts
@@ -1,0 +1,17 @@
+/** Framework-reserved controller method prefix. */
+export const SCOMP_FRAMEWORK_PREFIX = "__scomp.";
+
+/** Framework controller methods. */
+export const ScompFrameworkMethods = {
+  /** Tear down a feed subscription. Op: signal. */
+  UNSUBSCRIBE: "__scomp.unsubscribe",
+  /** Pause feed emission (reserved for future use). Op: signal. */
+  PAUSE: "__scomp.pause",
+  /** Resume feed emission (reserved for future use). Op: signal. */
+  RESUME: "__scomp.resume",
+  /** Query feed subscription stats (reserved for future use). Op: request. */
+  STATS: "__scomp.stats",
+} as const;
+
+export type ScompFrameworkMethod =
+  (typeof ScompFrameworkMethods)[keyof typeof ScompFrameworkMethods];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,18 @@
 export { createContractToken, type ContractToken } from "./contract-token";
 
 export {
+  SCOMP_FRAMEWORK_PREFIX,
+  ScompFrameworkMethods,
+  type ScompFrameworkMethod,
+} from "./framework-methods";
+
+export {
+  createControlledFeed,
+  type ControlledAsyncIterable,
+  type ControlledFeedOptions,
+} from "./controlled-feed";
+
+export {
   ScompFeed,
   createScompFeed,
   fromAsyncIterable,

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -5,6 +5,10 @@ import type {
 
 export interface ScompClientInvokeOptions extends ScompTransportPriorityHints {
   meta?: ScompTransportMessageMeta;
+  /** Feed subscription ID for controller-scoped calls. */
+  feed?: string;
+  /** Controller method name for controller-scoped calls. */
+  method?: string;
 }
 
 export interface ITransport {

--- a/packages/core/test/controlled-feed.spec.ts
+++ b/packages/core/test/controlled-feed.spec.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { createControlledFeed, type ControlledAsyncIterable } from "../src";
+
+async function* generate<T>(...values: T[]): AsyncIterable<T> {
+  for (const v of values) yield v;
+}
+
+describe("createControlledFeed", () => {
+  it("returns an object that is async-iterable", async () => {
+    const feed = createControlledFeed(generate(1, 2, 3), {});
+    const values: number[] = [];
+    for await (const v of feed) {
+      values.push(v);
+    }
+    assert.deepEqual(values, [1, 2, 3]);
+  });
+
+  it("exposes the provided methods via .controller", () => {
+    const methods = {
+      pause: () => Promise.resolve(),
+      seek: (offset: number) => Promise.resolve(offset * 2),
+    };
+    const feed = createControlledFeed(generate<string>(), methods);
+
+    assert.strictEqual(feed.controller, methods);
+    assert.equal(typeof feed.controller.pause, "function");
+    assert.equal(typeof feed.controller.seek, "function");
+  });
+
+  it("allows calling controller methods that return a value", async () => {
+    const methods = {
+      seek: (offset: number) => Promise.resolve(offset * 2),
+    };
+    const feed = createControlledFeed(generate<number>(), methods);
+
+    const result = await feed.controller.seek(5);
+    assert.equal(result, 10);
+  });
+
+  it("allows calling controller methods that return void", async () => {
+    let paused = false;
+    const methods = {
+      pause: (): Promise<void> => {
+        paused = true;
+        return Promise.resolve();
+      },
+    };
+    const feed = createControlledFeed(generate<number>(), methods);
+
+    await feed.controller.pause();
+    assert.equal(paused, true);
+  });
+
+  it("throws on controller method names with __scomp. prefix", () => {
+    assert.throws(
+      () =>
+        createControlledFeed(generate<number>(), {
+          "__scomp.internal": () => {},
+        }),
+      {
+        message:
+          'Controller method "__scomp.internal" uses reserved __scomp. prefix.',
+      },
+    );
+  });
+
+  it("throws on multiple __scomp. prefixed keys (first match)", () => {
+    assert.throws(
+      () =>
+        createControlledFeed(generate<number>(), {
+          legit: () => {},
+          "__scomp.foo": () => {},
+          "__scomp.bar": () => {},
+        }),
+      /uses reserved __scomp\. prefix/,
+    );
+  });
+
+  it("iterates values from the original iterable", async () => {
+    const source = generate("a", "b", "c");
+    const feed = createControlledFeed(source, { noop: () => {} });
+    const values: string[] = [];
+
+    for await (const v of feed) {
+      values.push(v);
+    }
+
+    assert.deepEqual(values, ["a", "b", "c"]);
+  });
+
+  it("works with an empty iterable", async () => {
+    const feed = createControlledFeed(generate<number>(), {});
+    const values: number[] = [];
+
+    for await (const v of feed) {
+      values.push(v);
+    }
+
+    assert.deepEqual(values, []);
+  });
+
+  it("accepts controller methods with mixed return types", async () => {
+    const methods = {
+      signal: (): Promise<void> => Promise.resolve(),
+      request: (x: number): Promise<number> => Promise.resolve(x + 1),
+      syncMethod: () => 42,
+    };
+    const feed: ControlledAsyncIterable<string, typeof methods> =
+      createControlledFeed(generate("x"), methods);
+
+    await feed.controller.signal();
+    const reqResult = await feed.controller.request(10);
+    const syncResult = feed.controller.syncMethod();
+
+    assert.equal(reqResult, 11);
+    assert.equal(syncResult, 42);
+  });
+
+  it("defaults to exclusive scope when no options given", () => {
+    const feed = createControlledFeed(generate(1), {});
+    assert.equal(feed.__scope, "exclusive");
+  });
+
+  it("sets __scope to 'fanout' when scope option is fanout", () => {
+    const feed = createControlledFeed(generate(1), {}, { scope: "fanout" });
+    assert.equal(feed.__scope, "fanout");
+  });
+
+  it("sets __scope to 'exclusive' when scope option is explicit", () => {
+    const feed = createControlledFeed(generate(1), {}, { scope: "exclusive" });
+    assert.equal(feed.__scope, "exclusive");
+  });
+});

--- a/packages/core/test/framework-methods.spec.ts
+++ b/packages/core/test/framework-methods.spec.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { SCOMP_FRAMEWORK_PREFIX, ScompFrameworkMethods } from "../src";
+
+describe("framework-methods", () => {
+  describe("SCOMP_FRAMEWORK_PREFIX", () => {
+    it("equals the __scomp. prefix", () => {
+      assert.equal(SCOMP_FRAMEWORK_PREFIX, "__scomp.");
+    });
+  });
+
+  describe("ScompFrameworkMethods", () => {
+    it("has UNSUBSCRIBE with correct value", () => {
+      assert.equal(ScompFrameworkMethods.UNSUBSCRIBE, "__scomp.unsubscribe");
+    });
+
+    it("has PAUSE with correct value", () => {
+      assert.equal(ScompFrameworkMethods.PAUSE, "__scomp.pause");
+    });
+
+    it("has RESUME with correct value", () => {
+      assert.equal(ScompFrameworkMethods.RESUME, "__scomp.resume");
+    });
+
+    it("has STATS with correct value", () => {
+      assert.equal(ScompFrameworkMethods.STATS, "__scomp.stats");
+    });
+
+    it("all values start with the framework prefix", () => {
+      for (const value of Object.values(ScompFrameworkMethods)) {
+        assert.ok(
+          value.startsWith(SCOMP_FRAMEWORK_PREFIX),
+          `Expected "${value}" to start with "${SCOMP_FRAMEWORK_PREFIX}"`,
+        );
+      }
+    });
+  });
+});

--- a/packages/transport-websocket-browser/src/index.ts
+++ b/packages/transport-websocket-browser/src/index.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
-import type { ITransport, ScompClientInvokeOptions } from "@scomp/core";
+import {
+  type ITransport,
+  type ScompClientInvokeOptions,
+  ScompFrameworkMethods,
+} from "@scomp/core";
 import type {
   ScompFeedChunkEnvelope,
   ScompTransportMessageMeta,
@@ -208,12 +212,21 @@ export class WebSocketBrowserTransport implements ITransport {
 
     const outboundMeta = await this.composeOutboundMeta(options, principal);
 
-    this.sendJson(socket, {
+    const envelope: Record<string, unknown> = {
       route,
       op: "signal",
       payload,
       meta: outboundMeta,
-    });
+    };
+
+    if (options?.feed) {
+      envelope.feed = options.feed;
+    }
+    if (options?.method) {
+      envelope.method = options.method;
+    }
+
+    this.sendJson(socket, envelope);
   }
 
   feed(
@@ -297,7 +310,7 @@ export class WebSocketBrowserTransport implements ITransport {
               route,
               op: "signal",
               feed: feedHash,
-              method: "__scomp.unsubscribe",
+              method: ScompFrameworkMethods.UNSUBSCRIBE,
               payload: {},
             });
           } catch (error) {
@@ -486,13 +499,22 @@ export class WebSocketBrowserTransport implements ITransport {
 
     const outboundMeta = await this.composeOutboundMeta(options, principal);
 
-    this.sendJson(socket, {
+    const envelope: ScompTransportRequestEnvelope = {
       id,
       route,
       op,
       payload,
       meta: outboundMeta,
-    } satisfies ScompTransportRequestEnvelope);
+    };
+
+    if (options?.feed) {
+      envelope.feed = options.feed;
+    }
+    if (options?.method) {
+      envelope.method = options.method;
+    }
+
+    this.sendJson(socket, envelope);
 
     return response;
   }

--- a/packages/transport-websocket-browser/src/index.ts
+++ b/packages/transport-websocket-browser/src/index.ts
@@ -210,13 +210,11 @@ export class WebSocketBrowserTransport implements ITransport {
       throw new Error(`signal not authorized for route: ${route}`);
     }
 
-    const outboundMeta = await this.composeOutboundMeta(options, principal);
-
     const envelope: Record<string, unknown> = {
       route,
       op: "signal",
       payload,
-      meta: outboundMeta,
+      meta: this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal)),
     };
 
     if (options?.feed) {

--- a/packages/transport-websocket-client/src/index.ts
+++ b/packages/transport-websocket-client/src/index.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
-import type { ITransport, ScompClientInvokeOptions } from "@scomp/core";
+import {
+  type ITransport,
+  type ScompClientInvokeOptions,
+  ScompFrameworkMethods,
+} from "@scomp/core";
 import type {
   ScompFeedChunkEnvelope,
   ScompTransportMessageMeta,
@@ -197,12 +201,21 @@ export class WebSocketClientTransport implements ITransport {
     if (!allowed) {
       throw new Error(`signal not authorized for route: ${route}`);
     }
-    this.sendJson(socket, {
+    const envelope: Record<string, unknown> = {
       route,
       op: "signal",
       payload,
       meta: this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal)),
-    });
+    };
+
+    if (options?.feed) {
+      envelope.feed = options.feed;
+    }
+    if (options?.method) {
+      envelope.method = options.method;
+    }
+
+    this.sendJson(socket, envelope);
   }
 
   feed(
@@ -260,7 +273,7 @@ export class WebSocketClientTransport implements ITransport {
             route,
             op: "signal",
             feed: feedHash,
-            method: "__scomp.unsubscribe",
+            method: ScompFrameworkMethods.UNSUBSCRIBE,
             payload: {},
           });
         }
@@ -418,13 +431,22 @@ export class WebSocketClientTransport implements ITransport {
       this.pendingRequests.set(id, { resolve, reject });
     });
 
-    this.sendJson(socket, {
+    const envelope: ScompTransportRequestEnvelope = {
       id,
       route,
       op,
       payload,
       meta: this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal)),
-    } satisfies ScompTransportRequestEnvelope);
+    };
+
+    if (options?.feed) {
+      envelope.feed = options.feed;
+    }
+    if (options?.method) {
+      envelope.method = options.method;
+    }
+
+    this.sendJson(socket, envelope);
 
     return response;
   }

--- a/packages/transport-websocket-server-runtime/src/index.ts
+++ b/packages/transport-websocket-server-runtime/src/index.ts
@@ -1,4 +1,9 @@
-import type { CompiledRoute } from "@scomp/core";
+import {
+  SCOMP_FRAMEWORK_PREFIX,
+  ScompFrameworkMethods,
+  type CompiledRoute,
+  type ControlledAsyncIterable,
+} from "@scomp/core";
 import {
   createFeedHash,
   type ScompErrorCode,
@@ -28,6 +33,7 @@ interface RunningFeed<Socket extends RuntimeSocket> {
   exchange: string;
   subscribers: Set<Socket>;
   abortController: AbortController;
+  controller?: Record<string, (payload: unknown) => unknown>;
 }
 
 export type TransportMessage = ScompTransportRequestEnvelope;
@@ -84,6 +90,17 @@ function ensureFeedIterable(value: unknown): AsyncIterable<unknown> {
   throw new Error("Feed route handler did not return an AsyncIterable.");
 }
 
+function isControlledAsyncIterable(
+  value: unknown,
+): value is ControlledAsyncIterable<unknown, Record<string, Function>> {
+  return (
+    value != null &&
+    typeof (value as ControlledAsyncIterable<unknown>).controller ===
+      "object" &&
+    (value as ControlledAsyncIterable<unknown>).controller !== null
+  );
+}
+
 function defaultToPrincipalMeta(
   principal: ScompTransportPrincipal | undefined,
 ): ScompTransportMessageMeta | undefined {
@@ -108,6 +125,14 @@ function defaultToPrincipalMeta(
 export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
   private router?: Record<string, CompiledRoute>;
   private readonly runningFeeds = new Map<string, RunningFeed<Socket>>();
+  /**
+   * Shared controllers for fanout feeds, keyed by route+feedHash.
+   * Multiple RunningFeed entries may reference the same shared controller.
+   */
+  private readonly sharedControllers = new Map<
+    string,
+    Record<string, (payload: unknown) => unknown>
+  >();
 
   constructor(private readonly config: WebSocketServerRuntimeConfig<Socket>) {}
 
@@ -155,8 +180,17 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
       return;
     }
 
-    if (op === "signal" && body.method === "__scomp.unsubscribe" && body.feed) {
+    if (
+      op === "signal" &&
+      body.method === ScompFrameworkMethods.UNSUBSCRIBE &&
+      body.feed
+    ) {
       this.handleFeedUnsubscribe(socket, body);
+      return;
+    }
+
+    if (body.feed && body.method) {
+      await this.handleControllerCall(socket, body, meta);
       return;
     }
 
@@ -215,6 +249,66 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
     this.replyWithPayload(socket, body.id, { ok: true });
   }
 
+  private async handleControllerCall(
+    socket: Socket,
+    body: TransportMessage,
+    meta?: ScompTransportMessageMeta,
+  ): Promise<void> {
+    const feedId = String(body.feed ?? "");
+    const method = String(body.method ?? "");
+
+    const running = this.runningFeeds.get(feedId);
+    if (!running) {
+      this.replyWithError(
+        socket,
+        body.id,
+        `Feed not found: ${feedId}`,
+        meta,
+        "FEED_NOT_FOUND",
+      );
+      return;
+    }
+
+    if (method.startsWith(SCOMP_FRAMEWORK_PREFIX)) {
+      this.replyWithError(
+        socket,
+        body.id,
+        `Framework method not implemented: ${method}`,
+        meta,
+        "CONTROLLER_NOT_FOUND",
+      );
+      return;
+    }
+
+    const controller = running.controller;
+    if (!controller || typeof controller[method] !== "function") {
+      this.replyWithError(
+        socket,
+        body.id,
+        `Controller method not found: ${method}`,
+        meta,
+        "CONTROLLER_NOT_FOUND",
+      );
+      return;
+    }
+
+    if ((body.op ?? "request") === "signal") {
+      try {
+        await controller[method](body.payload);
+      } catch {
+        // Signals are fire-and-forget and do not reply.
+      }
+      return;
+    }
+
+    try {
+      const result = await controller[method](body.payload);
+      this.replyWithPayload(socket, body.id, result, meta);
+    } catch (error) {
+      this.replyWithError(socket, body.id, error, meta);
+    }
+  }
+
   private async handleFeedRpc(
     socket: Socket,
     route: CompiledRoute,
@@ -252,6 +346,24 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
 
     const result = await this.config.invokeRoute(route, body);
     const iterable = ensureFeedIterable(result);
+
+    if (isControlledAsyncIterable(result)) {
+      const controllerRef = result.controller as Record<
+        string,
+        (payload: unknown) => unknown
+      >;
+
+      if (result.__scope === "fanout") {
+        const existing = this.sharedControllers.get(hash);
+        runningFeed.controller = existing ?? controllerRef;
+        if (!existing) {
+          this.sharedControllers.set(hash, controllerRef);
+        }
+      } else {
+        runningFeed.controller = controllerRef;
+      }
+    }
+
     setImmediate(() => {
       void this.publishFeed(runningFeed, iterable);
     });
@@ -286,6 +398,7 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
       });
     } finally {
       this.runningFeeds.delete(runningFeed.key);
+      this.sharedControllers.delete(runningFeed.key);
     }
   }
 


### PR DESCRIPTION
## Summary

- Implements the complete Controlled Feeds epic (scomp-zd4) covering 5 issues
- Adds ControlledAsyncIterable type, server-side controller routing, framework method constants, typed client proxy with Proxy-based dispatch, and exclusive/fanout controller scoping
- All 26 turbo tasks (build + test + lint) pass with 82 core tests green

## Issues

- scomp-2vs: ControlledAsyncIterable type and createControlledFeed() factory
- scomp-e8f: Wire protocol support for feed controller calls
- scomp-kmg: Framework controller methods (\_\_scomp.unsubscribe, etc.)
- scomp-39i: Client proxy support for controlled feed controllers
- scomp-c5f: Controller scoping for exclusive vs fanout feeds

## Key Changes

- **@scomp/core**: New `ControlledAsyncIterable<T, C>`, `createControlledFeed()`, `ScompFrameworkMethods` constants, `ControlledFeedOptions` with exclusive/fanout scoping
- **@scomp/client**: `ScompClientProxy` type resolves controlled feeds with typed `.controller`; `createControllerProxy()` dispatches via transport
- **@scomp/transport-websocket-server-runtime**: Server-side controller call routing with FEED_NOT_FOUND/CONTROLLER_NOT_FOUND error codes, fanout controller sharing
- **@scomp/transport-websocket-client/browser**: Include feed/method in outbound envelopes, use framework constants

## Depends on

- PR #17 (feature/core-v2-arch) — this PR is based on that branch

## PR Checklist

- [x] Correctness validated; no avoidable unsafe patterns
- [x] Defaults followed; any exception justified in PR notes
- [x] Files remain cohesive and under 400 lines
- [x] Functions are under 50 lines, nesting under 3 levels
- [x] Comments only for intent/invariants/tradeoffs
- [x] Tests added/updated proportional to risk
- [x] Lint and tests pass
