### PR TITLE
refactor: resolve all tech debt - transport shared package, Symbol scope, safeJsonParse, file splits

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@scomp/core": "workspace:*",
+        "@scomp/transport-shared": "workspace:*",
         "@scomp/types": "workspace:*",
       },
     },
@@ -102,8 +103,17 @@
       "version": "0.1.0",
       "dependencies": {
         "@scomp/core": "workspace:*",
+        "@scomp/transport-shared": "workspace:*",
         "@scomp/types": "workspace:*",
         "amqplib": "^0.10.9",
+      },
+    },
+    "packages/transport-shared": {
+      "name": "@scomp/transport-shared",
+      "version": "0.1.0",
+      "dependencies": {
+        "@scomp/core": "workspace:*",
+        "@scomp/types": "workspace:*",
       },
     },
     "packages/transport-websocket-browser": {
@@ -111,6 +121,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@scomp/core": "workspace:*",
+        "@scomp/transport-shared": "workspace:*",
         "@scomp/types": "workspace:*",
       },
     },
@@ -119,6 +130,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@scomp/core": "workspace:*",
+        "@scomp/transport-shared": "workspace:*",
         "@scomp/types": "workspace:*",
         "@types/ws": "^8.18.1",
         "ws": "^8.18.3",
@@ -129,6 +141,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@scomp/core": "workspace:*",
+        "@scomp/transport-shared": "workspace:*",
         "@scomp/transport-websocket-browser": "workspace:*",
         "@scomp/transport-websocket-client": "workspace:*",
         "@scomp/transport-websocket-server-runtime": "workspace:*",
@@ -140,6 +153,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@scomp/core": "workspace:*",
+        "@scomp/transport-shared": "workspace:*",
         "@scomp/transport-websocket-client": "workspace:*",
         "@scomp/transport-websocket-server-runtime": "workspace:*",
         "@scomp/types": "workspace:*",
@@ -152,6 +166,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@scomp/core": "workspace:*",
+        "@scomp/transport-shared": "workspace:*",
         "@scomp/types": "workspace:*",
       },
     },
@@ -538,6 +553,8 @@
     "@scomp/transport-inprocess": ["@scomp/transport-inprocess@workspace:packages/transport-inprocess"],
 
     "@scomp/transport-rabbitmq": ["@scomp/transport-rabbitmq@workspace:packages/transport-rabbitmq"],
+
+    "@scomp/transport-shared": ["@scomp/transport-shared@workspace:packages/transport-shared"],
 
     "@scomp/transport-websocket-browser": ["@scomp/transport-websocket-browser@workspace:packages/transport-websocket-browser"],
 

--- a/packages/core/src/controlled-feed.ts
+++ b/packages/core/src/controlled-feed.ts
@@ -1,3 +1,10 @@
+/**
+ * Cross-realm safe symbol used to tag the feed scoping mode on a
+ * {@link ControlledAsyncIterable}.  Prefer this over a plain string
+ * property so the key never collides with user-defined properties.
+ */
+export const SCOMP_SCOPE = Symbol.for("scomp.scope");
+
 export interface ControlledFeedOptions {
   /**
    * Feed scoping mode.
@@ -17,7 +24,7 @@ export interface ControlledAsyncIterable<
 > extends AsyncIterable<T> {
   readonly controller: C;
   /** @internal Feed scoping mode for the runtime. */
-  readonly __scope?: "exclusive" | "fanout";
+  readonly [SCOMP_SCOPE]?: "exclusive" | "fanout";
 }
 
 /**
@@ -46,6 +53,6 @@ export function createControlledFeed<T, C extends object>(
       return iterable[Symbol.asyncIterator]();
     },
     controller: controllerMethods,
-    __scope: options?.scope ?? "exclusive",
+    [SCOMP_SCOPE]: options?.scope ?? "exclusive",
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export {
 } from "./framework-methods";
 
 export {
+  SCOMP_SCOPE,
   createControlledFeed,
   type ControlledAsyncIterable,
   type ControlledFeedOptions,

--- a/packages/core/src/peer.ts
+++ b/packages/core/src/peer.ts
@@ -40,7 +40,9 @@ export interface CreateScompPeerConfig {
 }
 
 function generateNodeId(): string {
-  return `node-${Date.now().toString(36)}`;
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 8);
+  return `node-${timestamp}-${random}`;
 }
 
 /**

--- a/packages/core/test/controlled-feed.spec.ts
+++ b/packages/core/test/controlled-feed.spec.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
-import { createControlledFeed, type ControlledAsyncIterable } from "../src";
+import {
+  createControlledFeed,
+  SCOMP_SCOPE,
+  type ControlledAsyncIterable,
+} from "../src";
 
 async function* generate<T>(...values: T[]): AsyncIterable<T> {
   for (const v of values) yield v;
@@ -118,16 +122,16 @@ describe("createControlledFeed", () => {
 
   it("defaults to exclusive scope when no options given", () => {
     const feed = createControlledFeed(generate(1), {});
-    assert.equal(feed.__scope, "exclusive");
+    assert.equal(feed[SCOMP_SCOPE], "exclusive");
   });
 
-  it("sets __scope to 'fanout' when scope option is fanout", () => {
+  it("sets scope to 'fanout' when scope option is fanout", () => {
     const feed = createControlledFeed(generate(1), {}, { scope: "fanout" });
-    assert.equal(feed.__scope, "fanout");
+    assert.equal(feed[SCOMP_SCOPE], "fanout");
   });
 
-  it("sets __scope to 'exclusive' when scope option is explicit", () => {
+  it("sets scope to 'exclusive' when scope option is explicit", () => {
     const feed = createControlledFeed(generate(1), {}, { scope: "exclusive" });
-    assert.equal(feed.__scope, "exclusive");
+    assert.equal(feed[SCOMP_SCOPE], "exclusive");
   });
 });

--- a/packages/transport-browser-windows/package.json
+++ b/packages/transport-browser-windows/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@scomp/core": "workspace:*",
+    "@scomp/transport-shared": "workspace:*",
     "@scomp/types": "workspace:*"
   }
 }

--- a/packages/transport-browser-windows/src/shared-worker-internal.ts
+++ b/packages/transport-browser-windows/src/shared-worker-internal.ts
@@ -1,9 +1,4 @@
-import type { ScompClientInvokeOptions } from "@scomp/core";
-import {
-  createFeedHash,
-  type ScompTransportMessageMeta,
-  type ScompTransportPrincipal,
-} from "@scomp/types";
+import { createFeedHash } from "@scomp/types";
 import type {
   BrowserWindowsCanonicalPayloadHash,
   BrowserWindowsParticipantId,
@@ -48,72 +43,4 @@ export function createPayloadHash(
   payload: unknown,
 ): BrowserWindowsCanonicalPayloadHash {
   return createFeedHash(route, payload);
-}
-
-export function toPriorityMeta(
-  options?: ScompClientInvokeOptions,
-): ScompTransportMessageMeta | undefined {
-  if (!options) {
-    return undefined;
-  }
-
-  const { priority, priorityClass, deadlineAtMs, targetLatencyMs } = options;
-  if (
-    priority === undefined &&
-    priorityClass === undefined &&
-    deadlineAtMs === undefined &&
-    targetLatencyMs === undefined
-  ) {
-    return undefined;
-  }
-
-  const meta: ScompTransportMessageMeta = {};
-  if (priority !== undefined) {
-    meta.priority = priority;
-  }
-  if (priorityClass !== undefined) {
-    meta.priorityClass = priorityClass;
-  }
-  if (deadlineAtMs !== undefined) {
-    meta.deadlineAtMs = deadlineAtMs;
-  }
-  if (targetLatencyMs !== undefined) {
-    meta.targetLatencyMs = targetLatencyMs;
-  }
-  return meta;
-}
-
-export function mergeMeta(
-  baseMeta: ScompTransportMessageMeta | undefined,
-  overlayMeta: ScompTransportMessageMeta | undefined,
-): ScompTransportMessageMeta | undefined {
-  if (!baseMeta && !overlayMeta) {
-    return undefined;
-  }
-
-  return {
-    ...(baseMeta ?? {}),
-    ...(overlayMeta ?? {}),
-  };
-}
-
-export function toPrincipalMeta(
-  principal: ScompTransportPrincipal | undefined,
-): ScompTransportMessageMeta | undefined {
-  if (!principal) {
-    return undefined;
-  }
-
-  return {
-    auth: {
-      subject: principal.subject,
-      tenantId: principal.tenantId,
-      scopes: principal.scopes,
-      claims: principal.claims,
-      issuedAt: principal.issuedAt,
-      expiresAt: principal.expiresAt,
-      authType: principal.authType,
-    },
-    tenantId: principal.tenantId,
-  };
 }

--- a/packages/transport-browser-windows/src/transport-browser-windows-security.ts
+++ b/packages/transport-browser-windows/src/transport-browser-windows-security.ts
@@ -3,9 +3,13 @@ import type {
   ScompTransportMessageMeta,
   ScompTransportOperation,
   ScompTransportPrincipal,
-  ScompTransportSecurityContext,
 } from "@scomp/types";
-import { mergeMeta, toPrincipalMeta, toPriorityMeta } from "./shared-worker-internal";
+import {
+  checkSecurity,
+  mergeMeta,
+  toPrincipalMeta,
+  toPriorityMeta,
+} from "@scomp/transport-shared";
 import type { BrowserWindowsTransportConfig } from "./types";
 
 export class BrowserWindowsTransportSecurity {
@@ -40,8 +44,11 @@ export class BrowserWindowsTransportSecurity {
     const configMeta = await this.resolveConfigMeta();
     const optionsMeta = options?.meta;
     const priorityMeta = toPriorityMeta(options);
-    const effectiveMeta = mergeMeta(mergeMeta(configMeta, optionsMeta), priorityMeta);
-    const { allowed, principal } = await this.checkSecurity({
+    const effectiveMeta = mergeMeta(
+      mergeMeta(configMeta, optionsMeta),
+      priorityMeta,
+    );
+    const { allowed, principal } = await checkSecurity(this.config.security, {
       direction: "outbound",
       transport: "browser-windows",
       route,
@@ -66,7 +73,7 @@ export class BrowserWindowsTransportSecurity {
     payload: unknown,
     meta: ScompTransportMessageMeta | undefined,
   ): Promise<void> {
-    const { allowed } = await this.checkSecurity({
+    const { allowed } = await checkSecurity(this.config.security, {
       direction: "inbound",
       transport: "browser-windows",
       route,
@@ -78,29 +85,5 @@ export class BrowserWindowsTransportSecurity {
     if (!allowed) {
       throw new Error(`${operation} not authorized for route: ${route}`);
     }
-  }
-
-  private async checkSecurity(
-    ctx: Omit<ScompTransportSecurityContext, "principal">,
-  ): Promise<{ allowed: boolean; principal?: ScompTransportPrincipal }> {
-    const policy = this.config.security;
-    if (!policy) {
-      return { allowed: true };
-    }
-
-    const principal = policy.authenticate ? await policy.authenticate(ctx) : undefined;
-
-    if (!policy.authorize) {
-      return { allowed: true, principal: principal ?? undefined };
-    }
-
-    const allowed = Boolean(
-      await policy.authorize({
-        ...ctx,
-        principal: principal ?? undefined,
-      }),
-    );
-
-    return { allowed, principal: principal ?? undefined };
   }
 }

--- a/packages/transport-browser-windows/tsconfig.json
+++ b/packages/transport-browser-windows/tsconfig.json
@@ -6,6 +6,10 @@
     "outDir": "dist",
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
-  "references": [{ "path": "../core" }, { "path": "../types" }],
+  "references": [
+    { "path": "../core" },
+    { "path": "../transport-shared" },
+    { "path": "../types" }
+  ],
   "include": ["src/**/*"]
 }

--- a/packages/transport-rabbitmq/package.json
+++ b/packages/transport-rabbitmq/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@scomp/core": "workspace:*",
+    "@scomp/transport-shared": "workspace:*",
     "@scomp/types": "workspace:*",
     "amqplib": "^0.10.9"
   }

--- a/packages/transport-rabbitmq/src/index.ts
+++ b/packages/transport-rabbitmq/src/index.ts
@@ -1,181 +1,36 @@
-﻿import { randomUUID } from "node:crypto";
-import { once } from "node:events";
-import {
-  type CompiledRoute,
-  type ITransport,
-  type ScompPriorityDecision,
-  type ScompClientInvokeOptions,
-  resolveScompPriority,
-} from "@scomp/core";
-import {
-  createFeedHash,
-  type ScompErrorCode,
-  type ScompFeedChunkEnvelope,
-  type ScompTransportMessageMeta,
-  type ScompTransportPrincipal,
-  type ScompTransportSecurityContext,
-  type ScompTransportSecurityPolicy,
-  type ScompSerializer,
-  type ScompTransportRequestEnvelope,
-  type ScompTransportResponseEnvelope,
+import { randomUUID } from "node:crypto";
+import { type ITransport, type ScompClientInvokeOptions } from "@scomp/core";
+import type {
+  ScompTransportMessageMeta,
+  ScompSerializer,
+  ScompTransportRequestEnvelope,
 } from "@scomp/types";
-import amqp, {
-  type Channel,
-  type ChannelModel,
-  type ConsumeMessage,
-} from "amqplib";
+import type { Channel, ChannelModel } from "amqplib";
+import {
+  toPriorityMeta,
+  toPrincipalMeta,
+  mergeMeta,
+} from "@scomp/transport-shared";
 import { defaultJsonSerializer } from "./serialization";
-
-const SIGNAL_EXCHANGE = "scomp.signals";
-
-export class StreamClosedError extends Error {
-  constructor(streamHash: string) {
-    super(`Feed stream closed for hash: ${streamHash}`);
-    this.name = "StreamClosedError";
-  }
-}
-
-interface RunningFeed {
-  key: string;
-  exchange: string;
-  subscribers: number;
-  abortController: AbortController;
-}
-
-export interface RabbitMQTransportRetryConfig {
-  maxAttempts?: number;
-  baseDelayMs?: number;
-  maxDelayMs?: number;
-}
-
-export interface RabbitMQTransportSecurityConfig {
-  requireTls?: boolean;
-  maxPayloadBytes?: number;
-  policy?: ScompTransportSecurityPolicy;
-  authorize?: (ctx: {
-    direction: "inbound" | "outbound";
-    route: string;
-    operation: string;
-    payload: unknown;
-  }) => boolean | Promise<boolean>;
-}
-
-export interface RabbitMQTransportPerformanceConfig {
-  requestTimeoutMs?: number;
-  maxInFlightRequests?: number;
-  feedBufferHighWaterMark?: number;
-}
-
-export type RabbitMQTransportEvent =
-  | { type: "connection_opened" }
-  | { type: "connection_reconnect"; attempt: number }
-  | { type: "connection_closed"; reason?: string }
-  | { type: "channel_opened" }
-  | { type: "request_sent"; route: string; correlationId: string }
-  | {
-      type: "request_resolved";
-      route: string;
-      correlationId: string;
-      durationMs: number;
-    }
-  | {
-      type: "request_rejected";
-      route: string;
-      correlationId: string;
-      reason: string;
-    }
-  | {
-      type: "request_timeout";
-      route: string;
-      correlationId: string;
-      timeoutMs: number;
-    }
-  | { type: "signal_sent"; route: string }
-  | { type: "feed_started"; route: string; hash: string }
-  | { type: "feed_joined"; route: string; hash: string }
-  | { type: "feed_stopped"; route: string; hash: string }
-  | { type: "feed_aborted"; hash: string }
-  | { type: "publish_return"; exchange: string }
-  | {
-      type: "security_denied";
-      route: string;
-      operation: string;
-      direction: "inbound" | "outbound";
-    }
-  | {
-      type: "priority_decision";
-      direction: "inbound" | "outbound";
-      route: string;
-      operation: ScompTransportRequestEnvelope["op"];
-      source: ScompPriorityDecision["source"];
-      requested: ScompPriorityDecision["requested"];
-      effective: ScompPriorityDecision["effective"];
-    };
-
-export interface RabbitMQTransportObservabilityConfig {
-  onEvent?: (event: RabbitMQTransportEvent) => void;
-  now?: () => number;
-}
-
-export interface RabbitMQTransportConfig {
-  url: string;
-  prefetch?: number;
-  serviceName?: string;
-  serializer?: ScompSerializer;
-  retry?: RabbitMQTransportRetryConfig;
-  security?: RabbitMQTransportSecurityConfig;
-  performance?: RabbitMQTransportPerformanceConfig;
-  observability?: RabbitMQTransportObservabilityConfig;
-}
-
-type RouterTable = Record<string, CompiledRoute>;
-
-function toPriorityMeta(
-  options?: ScompClientInvokeOptions,
-): ScompTransportMessageMeta | undefined {
-  if (!options) {
-    return undefined;
-  }
-
-  const { priority, priorityClass, deadlineAtMs, targetLatencyMs } = options;
-  if (
-    priority === undefined &&
-    priorityClass === undefined &&
-    deadlineAtMs === undefined &&
-    targetLatencyMs === undefined
-  ) {
-    return undefined;
-  }
-
-  const meta: ScompTransportMessageMeta = {};
-  if (priority !== undefined) {
-    meta.priority = priority;
-  }
-  if (priorityClass !== undefined) {
-    meta.priorityClass = priorityClass;
-  }
-  if (deadlineAtMs !== undefined) {
-    meta.deadlineAtMs = deadlineAtMs;
-  }
-  if (targetLatencyMs !== undefined) {
-    meta.targetLatencyMs = targetLatencyMs;
-  }
-
-  return meta;
-}
-
-function toServiceName(route: string): string {
-  const parts = route.split(".");
-  return parts[0] ?? "default";
-}
-
-function toRpcQueue(serviceName: string): string {
-  return `scomp.rpc.${serviceName}`;
-}
-
-function toFeedExchange(hash: string): string {
-  return `scomp.live.${hash}`;
-}
+import {
+  SIGNAL_EXCHANGE,
+  StreamClosedError,
+  checkTransportSecurity,
+  buildPriorityDecisionEvent,
+  type RunningFeed,
+  type RabbitMQTransportConfig,
+  type RabbitMQTransportEvent,
+  type RouterTable,
+  toServiceName,
+  toRpcQueue,
+} from "./types";
+import { connectWithRetry } from "./rabbitmq-connection";
+import { handleRpcMessage } from "./rabbitmq-rpc";
+import {
+  sendRpc,
+  createFeedConsumer,
+  type ClientContext,
+} from "./rabbitmq-client";
 
 export class RabbitMQTransport implements ITransport {
   private readonly config: RabbitMQTransportConfig;
@@ -196,6 +51,11 @@ export class RabbitMQTransport implements ITransport {
   >();
   private readonly runningFeeds = new Map<string, RunningFeed>();
   private readonly exchangeToFeedKey = new Map<string, string>();
+  private readonly feedConsumer: (
+    route: string,
+    payload: unknown,
+    options?: ScompClientInvokeOptions,
+  ) => AsyncIterable<unknown>;
 
   constructor(config: RabbitMQTransportConfig) {
     this.config = config;
@@ -205,6 +65,12 @@ export class RabbitMQTransport implements ITransport {
     if (config.security?.requireTls && !config.url.startsWith("amqps://")) {
       throw new Error("RabbitMQTransport requires TLS but URL is not amqps://");
     }
+
+    this.feedConsumer = createFeedConsumer(
+      this.clientContext(),
+      (route, payload, options) => this.signal(route, payload, options),
+      () => this.getFeedBufferLimit(),
+    );
   }
 
   async registerRoutes(router: RouterTable): Promise<void> {
@@ -216,14 +82,10 @@ export class RabbitMQTransport implements ITransport {
       const exchange = message.fields.exchange;
       this.emitEvent({ type: "publish_return", exchange });
       const feedKey = this.exchangeToFeedKey.get(exchange);
-      if (!feedKey) {
-        return;
-      }
+      if (!feedKey) return;
 
       const runningFeed = this.runningFeeds.get(feedKey);
-      if (!runningFeed) {
-        return;
-      }
+      if (!runningFeed) return;
 
       this.emitEvent({ type: "feed_aborted", hash: feedKey });
       runningFeed.abortController.abort(new StreamClosedError(feedKey));
@@ -238,11 +100,8 @@ export class RabbitMQTransport implements ITransport {
       const rpcQueue = toRpcQueue(serviceName);
       await channel.assertQueue(rpcQueue, { durable: true });
       await channel.consume(rpcQueue, async (message) => {
-        if (!message) {
-          return;
-        }
-
-        await this.handleRpcMessage(message);
+        if (!message) return;
+        await handleRpcMessage(this.rpcContext(), message);
       });
     }
 
@@ -256,9 +115,7 @@ export class RabbitMQTransport implements ITransport {
       });
       await channel.bindQueue(signalQueue, SIGNAL_EXCHANGE, signalRoute.route);
       await channel.consume(signalQueue, async (message) => {
-        if (!message) {
-          return;
-        }
+        if (!message) return;
 
         const body = this.deserializeFromBuffer<ScompTransportRequestEnvelope>(
           message.content,
@@ -269,7 +126,7 @@ export class RabbitMQTransport implements ITransport {
           "signal",
           body.meta,
         );
-        const { allowed } = await this.checkSecurity({
+        const { allowed } = await checkTransportSecurity(this.config.security, {
           direction: "inbound",
           transport: "rabbitmq",
           route: signalRoute.route,
@@ -289,7 +146,13 @@ export class RabbitMQTransport implements ITransport {
         }
 
         channel.ack(message);
-        await this.invokeRoute(signalRoute, body);
+        const routeEntry = this.router?.[signalRoute.route];
+        if (routeEntry) {
+          const payload = routeEntry.parser
+            ? routeEntry.parser(body.payload)
+            : body.payload;
+          await routeEntry.handler(payload);
+        }
       });
     }
   }
@@ -299,7 +162,7 @@ export class RabbitMQTransport implements ITransport {
     payload: unknown,
     options?: ScompClientInvokeOptions,
   ): Promise<unknown> {
-    return this.sendRpc(route, "request", payload, options);
+    return sendRpc(this.clientContext(), route, "request", payload, options);
   }
 
   async signal(
@@ -308,16 +171,19 @@ export class RabbitMQTransport implements ITransport {
     options?: ScompClientInvokeOptions,
   ): Promise<void> {
     const priorityMeta = toPriorityMeta(options);
-    const baseMeta = this.mergeMeta(options?.meta, priorityMeta);
+    const baseMeta = mergeMeta(options?.meta, priorityMeta);
     this.emitPriorityDecision("outbound", route, "signal", baseMeta);
-    const { allowed, principal } = await this.checkSecurity({
-      direction: "outbound",
-      transport: "rabbitmq",
-      route,
-      operation: "signal",
-      payload,
-      meta: baseMeta,
-    });
+    const { allowed, principal } = await checkTransportSecurity(
+      this.config.security,
+      {
+        direction: "outbound",
+        transport: "rabbitmq",
+        route,
+        operation: "signal",
+        payload,
+        meta: baseMeta,
+      },
+    );
     if (!allowed) {
       this.emitEvent({
         type: "security_denied",
@@ -335,7 +201,7 @@ export class RabbitMQTransport implements ITransport {
       route,
       payload,
       op: "signal",
-      meta: this.mergeMeta(baseMeta, this.toMessageMeta(principal)),
+      meta: mergeMeta(baseMeta, toPrincipalMeta(principal)),
     } satisfies ScompTransportRequestEnvelope);
     this.assertPayloadSize(content);
     channel.publish(SIGNAL_EXCHANGE, route, content, {
@@ -353,26 +219,19 @@ export class RabbitMQTransport implements ITransport {
     this.exchangeToFeedKey.clear();
 
     const closeError = new Error("RabbitMQ transport closed.");
-    for (const reject of this.requestRejecters.values()) {
-      reject(closeError);
-    }
+    for (const reject of this.requestRejecters.values()) reject(closeError);
     this.requestRejecters.clear();
     this.requestResolvers.clear();
     this.requestStartTime.clear();
-
     this.replyQueue = "";
 
     const channel = this.channel;
     this.channel = undefined;
-    if (channel?.close) {
-      await channel.close();
-    }
+    if (channel?.close) await channel.close();
 
     const connection = this.connection;
     this.connection = undefined;
-    if (connection?.close) {
-      await connection.close();
-    }
+    if (connection?.close) await connection.close();
   }
 
   feed(
@@ -380,191 +239,60 @@ export class RabbitMQTransport implements ITransport {
     payload: unknown,
     options?: ScompClientInvokeOptions,
   ): AsyncIterable<unknown> {
-    const self = this;
+    return this.feedConsumer(route, payload, options);
+  }
 
+  private clientContext(): ClientContext {
     return {
-      async *[Symbol.asyncIterator]() {
-        const channel = await self.getChannel();
-        const handshake = (await self.sendRpc(
-          route,
-          "feed",
-          payload,
-          options,
-        )) as { exchange: string; feed: string };
-
-        const exchangeName = String(handshake.exchange);
-        const feedHash = String(handshake.feed);
-        const queueName = (
-          await channel.assertQueue("", { exclusive: true, durable: false })
-        ).queue;
-        await channel.bindQueue(queueName, exchangeName, "");
-
-        const queueBuffer: Array<unknown> = [];
-        const waiters: Array<() => void> = [];
-        let closed = false;
-        const feedBufferLimit = self.getFeedBufferLimit();
-
-        const { consumerTag } = await channel.consume(queueName, (message) => {
-          if (!message) {
-            return;
-          }
-
-          const parsed = self.deserializeFromBuffer<ScompFeedChunkEnvelope>(
-            message.content,
-          );
-          channel.ack(message);
-
-          if (parsed.type === "done") {
-            closed = true;
-          } else if (parsed.type === "error") {
-            closed = true;
-            queueBuffer.push(
-              Promise.reject(new Error(parsed.message ?? "Feed error")),
-            );
-          } else {
-            if (queueBuffer.length >= feedBufferLimit) {
-              closed = true;
-              queueBuffer.push(
-                Promise.reject(
-                  new Error(
-                    `Feed buffer high-water mark exceeded (${feedBufferLimit})`,
-                  ),
-                ),
-              );
-              return;
-            }
-            queueBuffer.push(parsed.payload);
-          }
-
-          waiters.shift()?.();
-        });
-
-        try {
-          while (true) {
-            if (queueBuffer.length > 0) {
-              const value = queueBuffer.shift();
-              if (value instanceof Promise) {
-                await value;
-              }
-              if (closed && value === undefined) {
-                return;
-              }
-              if (value !== undefined) {
-                yield value;
-              }
-            } else if (closed) {
-              return;
-            } else {
-              await new Promise<void>((resolve) => waiters.push(resolve));
-            }
-          }
-        } finally {
-          await channel.cancel(consumerTag);
-          await channel.unbindQueue(queueName, exchangeName, "");
-          await channel.deleteQueue(queueName);
-          self.emitEvent({ type: "feed_stopped", route, hash: feedHash });
-          await self.signal(route, {}, {
-            ...options,
-            meta: {
-              ...options?.meta,
-              __scomp_feed: feedHash,
-              __scomp_method: "__scomp.unsubscribe",
-            },
-          } as ScompClientInvokeOptions);
-        }
+      security: this.config.security,
+      serializer: this.serializer,
+      contentType: this.contentType,
+      getChannel: () => this.getChannel(),
+      emitEvent: (e) => this.emitEvent(e),
+      emitPriorityDecision: (d, r, o, m) =>
+        this.emitPriorityDecision(d, r, o, m),
+      assertPayloadSize: (p) => this.assertPayloadSize(p),
+      requestStartTime: this.requestStartTime,
+      requestResolvers: this.requestResolvers,
+      requestRejecters: this.requestRejecters,
+      getReplyQueue: () => this.replyQueue,
+      setReplyQueue: (q) => {
+        this.replyQueue = q;
       },
+      now: () => this.now(),
+      getRequestTimeoutMs: () => this.getRequestTimeoutMs(),
+      getMaxInFlightRequests: () => this.getMaxInFlightRequests(),
     };
   }
 
-  private async sendRpc(
-    route: string,
-    op: ScompTransportRequestEnvelope["op"],
-    payload: unknown,
-    options?: ScompClientInvokeOptions,
-  ): Promise<unknown> {
-    const priorityMeta = toPriorityMeta(options);
-    const baseMeta = this.mergeMeta(options?.meta, priorityMeta);
-    this.emitPriorityDecision("outbound", route, op, baseMeta);
-    const { allowed, principal } = await this.checkSecurity({
-      direction: "outbound",
-      transport: "rabbitmq",
-      route,
-      operation: op,
-      payload,
-      meta: baseMeta,
-    });
-    if (!allowed) {
-      this.emitEvent({
-        type: "security_denied",
-        route,
-        operation: op,
-        direction: "outbound",
-      });
-      throw new Error(`${op} not authorized for route: ${route}`);
-    }
-
-    if (this.requestResolvers.size >= this.getMaxInFlightRequests()) {
-      throw new Error(
-        `In-flight request limit reached: ${this.getMaxInFlightRequests()}`,
-      );
-    }
-
-    const channel = await this.getChannel();
-    await this.ensureReplyConsumer();
-
-    const correlationId = randomUUID();
-    this.requestStartTime.set(correlationId, this.now());
-
-    const replyPromise = new Promise<unknown>((resolve, reject) => {
-      this.requestResolvers.set(correlationId, resolve);
-      this.requestRejecters.set(correlationId, reject);
-    });
-
-    const serviceName = toServiceName(route);
-    const body = this.serializeToBuffer({
-      route,
-      payload,
-      op,
-      meta: this.mergeMeta(baseMeta, this.toMessageMeta(principal)),
-    } satisfies ScompTransportRequestEnvelope);
-    this.assertPayloadSize(body);
-
-    channel.sendToQueue(toRpcQueue(serviceName), body, {
-      correlationId,
-      replyTo: this.replyQueue,
+  private rpcContext() {
+    return {
+      router: this.router,
+      security: this.config.security,
+      getChannel: () => this.getChannel(),
+      serializeToBuffer: (v: unknown) => this.serializeToBuffer(v),
+      deserializeFromBuffer: <T>(v: Buffer) => this.deserializeFromBuffer<T>(v),
       contentType: this.contentType,
-    });
-
-    this.emitEvent({ type: "request_sent", route, correlationId });
-
-    const timeoutMs = this.getRequestTimeoutMs();
-    const timeoutPromise = new Promise<never>((_resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.requestResolvers.delete(correlationId);
-        this.requestRejecters.delete(correlationId);
-        this.requestStartTime.delete(correlationId);
-        this.emitEvent({
-          type: "request_timeout",
-          route,
-          correlationId,
-          timeoutMs,
-        });
-        reject(
-          new Error(
-            `Request timed out after ${timeoutMs}ms for route: ${route}`,
-          ),
-        );
-      }, timeoutMs);
-
-      void replyPromise.finally(() => clearTimeout(timer));
-    });
-
-    return Promise.race([replyPromise, timeoutPromise]);
+      serializer: this.serializer,
+      emitEvent: (e: RabbitMQTransportEvent) => this.emitEvent(e),
+      emitPriorityDecision: (
+        d: "inbound" | "outbound",
+        r: string,
+        o: ScompTransportRequestEnvelope["op"],
+        m?: ScompTransportMessageMeta,
+      ) => this.emitPriorityDecision(d, r, o, m),
+      runningFeeds: this.runningFeeds,
+      exchangeToFeedKey: this.exchangeToFeedKey,
+      getCurrentChannel: () => this.channel,
+    };
   }
 
   private async getConnection(): Promise<ChannelModel> {
     if (!this.connection) {
-      this.connection = await this.connectWithRetry();
+      this.connection = await connectWithRetry(
+        { ...this.config.retry, url: this.config.url },
+        (event) => this.emitEvent(event),
+      );
       this.emitEvent({ type: "connection_opened" });
       this.connection.on("close", () => {
         this.connection = undefined;
@@ -586,290 +314,12 @@ export class RabbitMQTransport implements ITransport {
       const connection = await this.getConnection();
       this.channel = await connection.createChannel();
       this.emitEvent({ type: "channel_opened" });
-      const channel = this.channel;
-      if (this.config.prefetch && channel) {
-        await channel.prefetch(this.config.prefetch);
+      if (this.config.prefetch && this.channel) {
+        await this.channel.prefetch(this.config.prefetch);
       }
     }
-
-    const channel = this.channel;
-    if (!channel) {
-      throw new Error("RabbitMQ channel is not initialized.");
-    }
-
-    return channel;
-  }
-
-  private async ensureReplyConsumer(): Promise<void> {
-    if (this.replyQueue) {
-      return;
-    }
-
-    const channel = await this.getChannel();
-    const asserted = await channel.assertQueue("", {
-      exclusive: true,
-      durable: false,
-      autoDelete: true,
-    });
-    this.replyQueue = asserted.queue;
-
-    await channel.consume(this.replyQueue, (message) => {
-      if (!message) {
-        return;
-      }
-
-      const correlationId = message.properties.correlationId;
-      const resolve = this.requestResolvers.get(correlationId);
-      const reject = this.requestRejecters.get(correlationId);
-
-      this.requestResolvers.delete(correlationId);
-      this.requestRejecters.delete(correlationId);
-
-      const body = this.deserializeFromBuffer<ScompTransportResponseEnvelope>(
-        message.content,
-      );
-      if ("error" in body) {
-        this.emitEvent({
-          type: "request_rejected",
-          route: "unknown",
-          correlationId,
-          reason: String(body.error),
-        });
-        reject?.(new Error(String(body.error)));
-      } else {
-        const startedAt =
-          this.requestStartTime.get(correlationId) ?? this.now();
-        this.emitEvent({
-          type: "request_resolved",
-          route: "unknown",
-          correlationId,
-          durationMs: this.now() - startedAt,
-        });
-        resolve?.(body.payload);
-      }
-      this.requestStartTime.delete(correlationId);
-
-      channel.ack(message);
-    });
-  }
-
-  private async handleRpcMessage(message: ConsumeMessage): Promise<void> {
-    const channel = await this.getChannel();
-    const body = this.deserializeFromBuffer<ScompTransportRequestEnvelope>(
-      message.content,
-    );
-    const route = String(body.route ?? "");
-    this.emitPriorityDecision("inbound", route, body.op, body.meta);
-    const { allowed } = await this.checkSecurity({
-      direction: "inbound",
-      transport: "rabbitmq",
-      route,
-      operation: body.op,
-      payload: body.payload,
-      meta: body.meta,
-    });
-    if (!allowed) {
-      channel.ack(message);
-      this.emitEvent({
-        type: "security_denied",
-        route,
-        operation: body.op,
-        direction: "inbound",
-      });
-      this.replyWithError(
-        message,
-        `Inbound operation not authorized for route: ${route}`,
-        "UNAUTHORIZED",
-      );
-      return;
-    }
-
-    const routeEntry = this.router?.[route];
-
-    if (!routeEntry) {
-      channel.ack(message);
-      this.replyWithError(
-        message,
-        `Route not found: ${route}`,
-        "ROUTE_NOT_FOUND",
-      );
-      return;
-    }
-
-    if (routeEntry.kind === "feed") {
-      await this.handleFeedRpc(routeEntry, message, body);
-      channel.ack(message);
-      return;
-    }
-
-    try {
-      const output = await this.invokeRoute(routeEntry, body);
-      this.replyWithPayload(message, output);
-    } catch (error) {
-      this.replyWithError(message, error);
-    } finally {
-      channel.ack(message);
-    }
-  }
-
-  private async handleFeedRpc(
-    route: CompiledRoute,
-    message: ConsumeMessage,
-    body: ScompTransportRequestEnvelope,
-  ): Promise<void> {
-    const rawPayload = body.payload;
-    const parsedPayload = route.parser ? route.parser(rawPayload) : rawPayload;
-    const hash = String(
-      body.feed ??
-        createFeedHash(route.route, parsedPayload, { hashKey: route.hashKey }),
-    );
-
-    const existing = this.runningFeeds.get(hash);
-    if (existing) {
-      existing.subscribers += 1;
-      this.emitEvent({ type: "feed_joined", route: route.route, hash });
-      this.replyWithPayload(message, {
-        exchange: existing.exchange,
-        feed: hash,
-      });
-      return;
-    }
-
-    const exchange = toFeedExchange(hash);
-    const channel = await this.getChannel();
-    await channel.assertExchange(exchange, "fanout", {
-      durable: false,
-      autoDelete: true,
-    });
-
-    const runningFeed: RunningFeed = {
-      key: hash,
-      exchange,
-      subscribers: 1,
-      abortController: new AbortController(),
-    };
-    this.runningFeeds.set(hash, runningFeed);
-    this.exchangeToFeedKey.set(exchange, hash);
-    this.emitEvent({ type: "feed_started", route: route.route, hash });
-
-    const iterable = route.handler(parsedPayload) as AsyncIterable<unknown>;
-    void this.publishFeed(runningFeed, iterable);
-
-    this.replyWithPayload(message, { exchange, feed: hash });
-  }
-
-  private async publishFeed(
-    runningFeed: RunningFeed,
-    iterable: AsyncIterable<unknown>,
-  ): Promise<void> {
-    const channel = await this.getChannel();
-
-    try {
-      for await (const chunk of iterable) {
-        if (runningFeed.abortController.signal.aborted) {
-          throw runningFeed.abortController.signal.reason;
-        }
-
-        channel.publish(
-          runningFeed.exchange,
-          "",
-          this.serializeToBuffer({
-            channel: "feed",
-            feed: runningFeed.key,
-            type: "next",
-            payload: chunk,
-          } satisfies ScompFeedChunkEnvelope),
-          {
-            contentType: this.contentType,
-            mandatory: true,
-          },
-        );
-        await this.waitForChannelDrainIfNeeded(channel);
-      }
-
-      channel.publish(
-        runningFeed.exchange,
-        "",
-        this.serializeToBuffer({
-          channel: "feed",
-          feed: runningFeed.key,
-          type: "done",
-        } satisfies ScompFeedChunkEnvelope),
-        {
-          contentType: this.contentType,
-          mandatory: true,
-        },
-      );
-      await this.waitForChannelDrainIfNeeded(channel);
-    } catch (error) {
-      channel.publish(
-        runningFeed.exchange,
-        "",
-        this.serializeToBuffer({
-          channel: "feed",
-          feed: runningFeed.key,
-          type: "error",
-          message: error instanceof Error ? error.message : String(error),
-        } satisfies ScompFeedChunkEnvelope),
-        {
-          contentType: this.contentType,
-          mandatory: true,
-        },
-      );
-      await this.waitForChannelDrainIfNeeded(channel);
-    } finally {
-      this.runningFeeds.delete(runningFeed.key);
-      this.exchangeToFeedKey.delete(runningFeed.exchange);
-    }
-  }
-
-  private async invokeRoute(
-    route: CompiledRoute,
-    body: ScompTransportRequestEnvelope,
-  ): Promise<unknown> {
-    const payload = route.parser ? route.parser(body.payload) : body.payload;
-    return route.handler(payload);
-  }
-
-  private replyWithPayload(message: ConsumeMessage, payload: unknown): void {
-    const replyTo = message.properties.replyTo;
-    if (!replyTo) {
-      return;
-    }
-
-    this.channel?.sendToQueue(
-      replyTo,
-      this.serializeToBuffer({
-        payload,
-      } satisfies ScompTransportResponseEnvelope),
-      {
-        correlationId: message.properties.correlationId,
-        contentType: this.contentType,
-      },
-    );
-  }
-
-  private replyWithError(
-    message: ConsumeMessage,
-    error: unknown,
-    code?: ScompErrorCode,
-  ): void {
-    const replyTo = message.properties.replyTo;
-    if (!replyTo) {
-      return;
-    }
-
-    this.channel?.sendToQueue(
-      replyTo,
-      this.serializeToBuffer({
-        error: error instanceof Error ? error.message : String(error),
-        code,
-      } satisfies ScompTransportResponseEnvelope),
-      {
-        correlationId: message.properties.correlationId,
-        contentType: this.contentType,
-      },
-    );
+    if (!this.channel) throw new Error("RabbitMQ channel is not initialized.");
+    return this.channel;
   }
 
   private serializeToBuffer(value: unknown): Buffer {
@@ -882,121 +332,8 @@ export class RabbitMQTransport implements ITransport {
 
   private assertPayloadSize(payload: Buffer): void {
     const limit = this.config.security?.maxPayloadBytes;
-    if (!limit) {
-      return;
-    }
-
-    if (payload.byteLength > limit) {
+    if (limit && payload.byteLength > limit) {
       throw new Error(`Payload exceeds maxPayloadBytes (${limit}).`);
-    }
-  }
-
-  private toMessageMeta(
-    principal: ScompTransportPrincipal | undefined,
-  ): ScompTransportMessageMeta | undefined {
-    if (!principal) {
-      return undefined;
-    }
-
-    return {
-      auth: {
-        subject: principal.subject,
-        tenantId: principal.tenantId,
-        scopes: principal.scopes,
-        claims: principal.claims,
-        issuedAt: principal.issuedAt,
-        expiresAt: principal.expiresAt,
-        authType: principal.authType,
-      },
-      tenantId: principal.tenantId,
-    };
-  }
-
-  private mergeMeta(
-    baseMeta: ScompTransportMessageMeta | undefined,
-    overlayMeta: ScompTransportMessageMeta | undefined,
-  ): ScompTransportMessageMeta | undefined {
-    if (!baseMeta && !overlayMeta) {
-      return undefined;
-    }
-
-    return {
-      ...(baseMeta ?? {}),
-      ...(overlayMeta ?? {}),
-    };
-  }
-
-  private async checkSecurity(
-    ctx: Omit<ScompTransportSecurityContext, "principal">,
-  ): Promise<{ allowed: boolean; principal?: ScompTransportPrincipal }> {
-    const policy = this.config.security?.policy;
-
-    const principal = policy?.authenticate
-      ? await policy.authenticate(ctx)
-      : undefined;
-
-    if (policy?.authorize) {
-      const allowed = Boolean(
-        await policy.authorize({ ...ctx, principal: principal ?? undefined }),
-      );
-      return { allowed, principal: principal ?? undefined };
-    }
-
-    const legacyAuthorize = this.config.security?.authorize;
-    if (legacyAuthorize) {
-      const allowed = Boolean(
-        await legacyAuthorize({
-          direction: ctx.direction,
-          route: ctx.route,
-          operation: ctx.operation,
-          payload: ctx.payload,
-        }),
-      );
-      return { allowed, principal: principal ?? undefined };
-    }
-
-    return { allowed: true, principal: principal ?? undefined };
-  }
-
-  private async connectWithRetry(): Promise<ChannelModel> {
-    const maxAttempts = this.config.retry?.maxAttempts ?? 6;
-    const baseDelayMs = this.config.retry?.baseDelayMs ?? 250;
-    const maxDelayMs = this.config.retry?.maxDelayMs ?? 8_000;
-
-    let attempt = 0;
-    let lastError: unknown;
-
-    while (attempt < maxAttempts) {
-      attempt += 1;
-      try {
-        if (attempt > 1) {
-          this.emitEvent({ type: "connection_reconnect", attempt });
-        }
-        return await amqp.connect(this.config.url);
-      } catch (error) {
-        lastError = error;
-        if (attempt >= maxAttempts) {
-          break;
-        }
-
-        const jitter = Math.floor(Math.random() * 100);
-        const delay = Math.min(
-          maxDelayMs,
-          baseDelayMs * 2 ** (attempt - 1) + jitter,
-        );
-        await new Promise((resolve) => setTimeout(resolve, delay));
-      }
-    }
-
-    throw new Error(
-      `Unable to connect to RabbitMQ after ${maxAttempts} attempts: ${String(lastError)}`,
-    );
-  }
-
-  private async waitForChannelDrainIfNeeded(channel: Channel): Promise<void> {
-    const writable = (channel as unknown as { writable?: boolean }).writable;
-    if (writable === false) {
-      await once(channel, "drain");
     }
   }
 
@@ -1010,22 +347,9 @@ export class RabbitMQTransport implements ITransport {
     operation: ScompTransportRequestEnvelope["op"],
     meta?: ScompTransportMessageMeta,
   ): void {
-    const decision = resolveScompPriority({
-      route,
-      operation,
-      meta: meta as
-        | (ScompTransportMessageMeta & Record<string, unknown>)
-        | undefined,
-    });
-    this.emitEvent({
-      type: "priority_decision",
-      direction,
-      route,
-      operation,
-      source: decision.source,
-      requested: decision.requested,
-      effective: decision.effective,
-    });
+    this.emitEvent(
+      buildPriorityDecisionEvent(direction, route, operation, meta),
+    );
   }
 
   private now(): number {
@@ -1050,6 +374,16 @@ export function createRabbitMqTransport(
 ): RabbitMQTransport {
   return new RabbitMQTransport(config);
 }
+
+export {
+  StreamClosedError,
+  type RabbitMQTransportRetryConfig,
+  type RabbitMQTransportSecurityConfig,
+  type RabbitMQTransportPerformanceConfig,
+  type RabbitMQTransportEvent,
+  type RabbitMQTransportObservabilityConfig,
+  type RabbitMQTransportConfig,
+} from "./types";
 
 export {
   createJsonSerializer,

--- a/packages/transport-rabbitmq/src/rabbitmq-client.ts
+++ b/packages/transport-rabbitmq/src/rabbitmq-client.ts
@@ -1,0 +1,310 @@
+import { randomUUID } from "node:crypto";
+import type { ScompClientInvokeOptions } from "@scomp/core";
+import type {
+  ScompFeedChunkEnvelope,
+  ScompSerializer,
+  ScompTransportMessageMeta,
+  ScompTransportPrincipal,
+  ScompTransportRequestEnvelope,
+  ScompTransportResponseEnvelope,
+} from "@scomp/types";
+import type { Channel } from "amqplib";
+import {
+  toPriorityMeta,
+  toPrincipalMeta,
+  mergeMeta,
+} from "@scomp/transport-shared";
+import {
+  checkTransportSecurity,
+  type RabbitMQTransportEvent,
+  type RabbitMQTransportSecurityConfig,
+  toServiceName,
+  toRpcQueue,
+} from "./types";
+
+export interface ClientContext {
+  security?: RabbitMQTransportSecurityConfig;
+  serializer: ScompSerializer;
+  contentType: string;
+  getChannel: () => Promise<Channel>;
+  emitEvent: (event: RabbitMQTransportEvent) => void;
+  emitPriorityDecision: (
+    direction: "inbound" | "outbound",
+    route: string,
+    operation: ScompTransportRequestEnvelope["op"],
+    meta?: ScompTransportMessageMeta,
+  ) => void;
+  assertPayloadSize: (payload: Buffer) => void;
+  requestStartTime: Map<string, number>;
+  requestResolvers: Map<string, (value: unknown) => void>;
+  requestRejecters: Map<string, (error: unknown) => void>;
+  getReplyQueue: () => string;
+  setReplyQueue: (queue: string) => void;
+  now: () => number;
+  getRequestTimeoutMs: () => number;
+  getMaxInFlightRequests: () => number;
+}
+
+export async function sendRpc(
+  ctx: ClientContext,
+  route: string,
+  op: ScompTransportRequestEnvelope["op"],
+  payload: unknown,
+  options?: ScompClientInvokeOptions,
+): Promise<unknown> {
+  const priorityMeta = toPriorityMeta(options);
+  const baseMeta = mergeMeta(options?.meta, priorityMeta);
+  ctx.emitPriorityDecision("outbound", route, op, baseMeta);
+  const { allowed, principal } = await checkTransportSecurity(ctx.security, {
+    direction: "outbound",
+    transport: "rabbitmq",
+    route,
+    operation: op,
+    payload,
+    meta: baseMeta,
+  });
+  if (!allowed) {
+    ctx.emitEvent({
+      type: "security_denied",
+      route,
+      operation: op,
+      direction: "outbound",
+    });
+    throw new Error(`${op} not authorized for route: ${route}`);
+  }
+
+  if (ctx.requestResolvers.size >= ctx.getMaxInFlightRequests()) {
+    throw new Error(
+      `In-flight request limit reached: ${ctx.getMaxInFlightRequests()}`,
+    );
+  }
+
+  const channel = await ctx.getChannel();
+  await ensureReplyConsumer(ctx);
+
+  const correlationId = randomUUID();
+  ctx.requestStartTime.set(correlationId, ctx.now());
+
+  const replyPromise = new Promise<unknown>((resolve, reject) => {
+    ctx.requestResolvers.set(correlationId, resolve);
+    ctx.requestRejecters.set(correlationId, reject);
+  });
+
+  const serviceName = toServiceName(route);
+  const body = serializeToBuffer(ctx.serializer, {
+    route,
+    payload,
+    op,
+    meta: mergeMeta(baseMeta, toPrincipalMeta(principal)),
+  } satisfies ScompTransportRequestEnvelope);
+  ctx.assertPayloadSize(body);
+
+  channel.sendToQueue(toRpcQueue(serviceName), body, {
+    correlationId,
+    replyTo: ctx.getReplyQueue(),
+    contentType: ctx.contentType,
+  });
+
+  ctx.emitEvent({ type: "request_sent", route, correlationId });
+
+  const timeoutMs = ctx.getRequestTimeoutMs();
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    const timer = setTimeout(() => {
+      ctx.requestResolvers.delete(correlationId);
+      ctx.requestRejecters.delete(correlationId);
+      ctx.requestStartTime.delete(correlationId);
+      ctx.emitEvent({
+        type: "request_timeout",
+        route,
+        correlationId,
+        timeoutMs,
+      });
+      reject(
+        new Error(`Request timed out after ${timeoutMs}ms for route: ${route}`),
+      );
+    }, timeoutMs);
+
+    void replyPromise.finally(() => clearTimeout(timer));
+  });
+
+  return Promise.race([replyPromise, timeoutPromise]);
+}
+
+async function ensureReplyConsumer(ctx: ClientContext): Promise<void> {
+  if (ctx.getReplyQueue()) {
+    return;
+  }
+
+  const channel = await ctx.getChannel();
+  const asserted = await channel.assertQueue("", {
+    exclusive: true,
+    durable: false,
+    autoDelete: true,
+  });
+  ctx.setReplyQueue(asserted.queue);
+
+  await channel.consume(asserted.queue, (message) => {
+    if (!message) {
+      return;
+    }
+
+    const correlationId = message.properties.correlationId;
+    const resolve = ctx.requestResolvers.get(correlationId);
+    const reject = ctx.requestRejecters.get(correlationId);
+
+    ctx.requestResolvers.delete(correlationId);
+    ctx.requestRejecters.delete(correlationId);
+
+    const body = deserializeFromBuffer<ScompTransportResponseEnvelope>(
+      ctx.serializer,
+      message.content,
+    );
+    if ("error" in body) {
+      ctx.emitEvent({
+        type: "request_rejected",
+        route: "unknown",
+        correlationId,
+        reason: String(body.error),
+      });
+      reject?.(new Error(String(body.error)));
+    } else {
+      const startedAt = ctx.requestStartTime.get(correlationId) ?? ctx.now();
+      ctx.emitEvent({
+        type: "request_resolved",
+        route: "unknown",
+        correlationId,
+        durationMs: ctx.now() - startedAt,
+      });
+      resolve?.(body.payload);
+    }
+    ctx.requestStartTime.delete(correlationId);
+
+    channel.ack(message);
+  });
+}
+
+export function createFeedConsumer(
+  ctx: ClientContext,
+  signal: (
+    route: string,
+    payload: unknown,
+    options?: ScompClientInvokeOptions,
+  ) => Promise<void>,
+  getFeedBufferLimit: () => number,
+): (
+  route: string,
+  payload: unknown,
+  options?: ScompClientInvokeOptions,
+) => AsyncIterable<unknown> {
+  return (route, payload, options) => ({
+    async *[Symbol.asyncIterator]() {
+      const channel = await ctx.getChannel();
+      const handshake = (await sendRpc(
+        ctx,
+        route,
+        "feed",
+        payload,
+        options,
+      )) as {
+        exchange: string;
+        feed: string;
+      };
+
+      const exchangeName = String(handshake.exchange);
+      const feedHash = String(handshake.feed);
+      const queueName = (
+        await channel.assertQueue("", { exclusive: true, durable: false })
+      ).queue;
+      await channel.bindQueue(queueName, exchangeName, "");
+
+      const queueBuffer: Array<unknown> = [];
+      const waiters: Array<() => void> = [];
+      let closed = false;
+      const feedBufferLimit = getFeedBufferLimit();
+
+      const { consumerTag } = await channel.consume(queueName, (message) => {
+        if (!message) {
+          return;
+        }
+
+        const parsed = deserializeFromBuffer<ScompFeedChunkEnvelope>(
+          ctx.serializer,
+          message.content,
+        );
+        channel.ack(message);
+
+        if (parsed.type === "done") {
+          closed = true;
+        } else if (parsed.type === "error") {
+          closed = true;
+          queueBuffer.push(
+            Promise.reject(new Error(parsed.message ?? "Feed error")),
+          );
+        } else {
+          if (queueBuffer.length >= feedBufferLimit) {
+            closed = true;
+            queueBuffer.push(
+              Promise.reject(
+                new Error(
+                  `Feed buffer high-water mark exceeded (${feedBufferLimit})`,
+                ),
+              ),
+            );
+            return;
+          }
+          queueBuffer.push(parsed.payload);
+        }
+
+        waiters.shift()?.();
+      });
+
+      try {
+        while (true) {
+          if (queueBuffer.length > 0) {
+            const value = queueBuffer.shift();
+            if (value instanceof Promise) {
+              await value;
+            }
+            if (closed && value === undefined) {
+              return;
+            }
+            if (value !== undefined) {
+              yield value;
+            }
+          } else if (closed) {
+            return;
+          } else {
+            await new Promise<void>((resolve) => waiters.push(resolve));
+          }
+        }
+      } finally {
+        await channel.cancel(consumerTag);
+        await channel.unbindQueue(queueName, exchangeName, "");
+        await channel.deleteQueue(queueName);
+        ctx.emitEvent({ type: "feed_stopped", route, hash: feedHash });
+        await signal(route, {}, {
+          ...options,
+          meta: {
+            ...options?.meta,
+            __scomp_feed: feedHash,
+            __scomp_method: "__scomp.unsubscribe",
+          },
+        } as ScompClientInvokeOptions);
+      }
+    },
+  });
+}
+
+function serializeToBuffer(
+  serializer: ScompSerializer,
+  value: unknown,
+): Buffer {
+  return Buffer.from(serializer.stringify(value));
+}
+
+function deserializeFromBuffer<T = unknown>(
+  serializer: ScompSerializer,
+  value: Buffer,
+): T {
+  return serializer.parse<T>(value.toString("utf8"));
+}

--- a/packages/transport-rabbitmq/src/rabbitmq-connection.ts
+++ b/packages/transport-rabbitmq/src/rabbitmq-connection.ts
@@ -1,0 +1,43 @@
+import amqp, { type ChannelModel } from "amqplib";
+import type {
+  RabbitMQTransportRetryConfig,
+  RabbitMQTransportEvent,
+} from "./types";
+
+export async function connectWithRetry(
+  config: RabbitMQTransportRetryConfig & { url: string },
+  emitEvent: (event: RabbitMQTransportEvent) => void,
+): Promise<ChannelModel> {
+  const maxAttempts = config.maxAttempts ?? 6;
+  const baseDelayMs = config.baseDelayMs ?? 250;
+  const maxDelayMs = config.maxDelayMs ?? 8_000;
+
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    try {
+      if (attempt > 1) {
+        emitEvent({ type: "connection_reconnect", attempt });
+      }
+      return await amqp.connect(config.url);
+    } catch (error) {
+      lastError = error;
+      if (attempt >= maxAttempts) {
+        break;
+      }
+
+      const jitter = Math.floor(Math.random() * 100);
+      const delay = Math.min(
+        maxDelayMs,
+        baseDelayMs * 2 ** (attempt - 1) + jitter,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw new Error(
+    `Unable to connect to RabbitMQ after ${maxAttempts} attempts: ${String(lastError)}`,
+  );
+}

--- a/packages/transport-rabbitmq/src/rabbitmq-feed.ts
+++ b/packages/transport-rabbitmq/src/rabbitmq-feed.ts
@@ -1,0 +1,82 @@
+import { once } from "node:events";
+import type { Channel } from "amqplib";
+import type { ScompFeedChunkEnvelope, ScompSerializer } from "@scomp/types";
+import type { RunningFeed } from "./types";
+
+export async function waitForChannelDrainIfNeeded(
+  channel: Channel,
+): Promise<void> {
+  const writable = (channel as unknown as { writable?: boolean }).writable;
+  if (writable === false) {
+    await once(channel, "drain");
+  }
+}
+
+export async function publishFeed(
+  channel: Channel,
+  runningFeed: RunningFeed,
+  iterable: AsyncIterable<unknown>,
+  serializer: ScompSerializer,
+  contentType: string,
+  onComplete: (feed: RunningFeed) => void,
+): Promise<void> {
+  const serializeToBuffer = (value: unknown): Buffer =>
+    Buffer.from(serializer.stringify(value));
+
+  try {
+    for await (const chunk of iterable) {
+      if (runningFeed.abortController.signal.aborted) {
+        throw runningFeed.abortController.signal.reason;
+      }
+
+      channel.publish(
+        runningFeed.exchange,
+        "",
+        serializeToBuffer({
+          channel: "feed",
+          feed: runningFeed.key,
+          type: "next",
+          payload: chunk,
+        } satisfies ScompFeedChunkEnvelope),
+        {
+          contentType,
+          mandatory: true,
+        },
+      );
+      await waitForChannelDrainIfNeeded(channel);
+    }
+
+    channel.publish(
+      runningFeed.exchange,
+      "",
+      serializeToBuffer({
+        channel: "feed",
+        feed: runningFeed.key,
+        type: "done",
+      } satisfies ScompFeedChunkEnvelope),
+      {
+        contentType,
+        mandatory: true,
+      },
+    );
+    await waitForChannelDrainIfNeeded(channel);
+  } catch (error) {
+    channel.publish(
+      runningFeed.exchange,
+      "",
+      serializeToBuffer({
+        channel: "feed",
+        feed: runningFeed.key,
+        type: "error",
+        message: error instanceof Error ? error.message : String(error),
+      } satisfies ScompFeedChunkEnvelope),
+      {
+        contentType,
+        mandatory: true,
+      },
+    );
+    await waitForChannelDrainIfNeeded(channel);
+  } finally {
+    onComplete(runningFeed);
+  }
+}

--- a/packages/transport-rabbitmq/src/rabbitmq-rpc.ts
+++ b/packages/transport-rabbitmq/src/rabbitmq-rpc.ts
@@ -1,0 +1,212 @@
+import type { CompiledRoute } from "@scomp/core";
+import {
+  createFeedHash,
+  type ScompErrorCode,
+  type ScompTransportRequestEnvelope,
+  type ScompTransportResponseEnvelope,
+} from "@scomp/types";
+import type { Channel, ConsumeMessage } from "amqplib";
+import {
+  checkTransportSecurity,
+  type RabbitMQTransportEvent,
+  type RabbitMQTransportSecurityConfig,
+  type RunningFeed,
+  type RouterTable,
+  toFeedExchange,
+} from "./types";
+import { publishFeed } from "./rabbitmq-feed";
+
+export interface RpcContext {
+  router?: RouterTable;
+  security?: RabbitMQTransportSecurityConfig;
+  getChannel: () => Promise<Channel>;
+  serializeToBuffer: (value: unknown) => Buffer;
+  deserializeFromBuffer: <T = unknown>(value: Buffer) => T;
+  contentType: string;
+  serializer: import("@scomp/types").ScompSerializer;
+  emitEvent: (event: RabbitMQTransportEvent) => void;
+  emitPriorityDecision: (
+    direction: "inbound" | "outbound",
+    route: string,
+    operation: ScompTransportRequestEnvelope["op"],
+    meta?: import("@scomp/types").ScompTransportMessageMeta,
+  ) => void;
+  runningFeeds: Map<string, RunningFeed>;
+  exchangeToFeedKey: Map<string, string>;
+  getCurrentChannel: () => Channel | undefined;
+}
+
+export async function handleRpcMessage(
+  ctx: RpcContext,
+  message: ConsumeMessage,
+): Promise<void> {
+  const channel = await ctx.getChannel();
+  const body = ctx.deserializeFromBuffer<ScompTransportRequestEnvelope>(
+    message.content,
+  );
+  const route = String(body.route ?? "");
+  ctx.emitPriorityDecision("inbound", route, body.op, body.meta);
+  const { allowed } = await checkTransportSecurity(ctx.security, {
+    direction: "inbound",
+    transport: "rabbitmq",
+    route,
+    operation: body.op,
+    payload: body.payload,
+    meta: body.meta,
+  });
+  if (!allowed) {
+    channel.ack(message);
+    ctx.emitEvent({
+      type: "security_denied",
+      route,
+      operation: body.op,
+      direction: "inbound",
+    });
+    replyWithError(
+      ctx,
+      message,
+      `Inbound operation not authorized for route: ${route}`,
+      "UNAUTHORIZED",
+    );
+    return;
+  }
+
+  const routeEntry = ctx.router?.[route];
+
+  if (!routeEntry) {
+    channel.ack(message);
+    replyWithError(
+      ctx,
+      message,
+      `Route not found: ${route}`,
+      "ROUTE_NOT_FOUND",
+    );
+    return;
+  }
+
+  if (routeEntry.kind === "feed") {
+    await handleFeedRpc(ctx, routeEntry, message, body);
+    channel.ack(message);
+    return;
+  }
+
+  try {
+    const output = await invokeRoute(routeEntry, body);
+    replyWithPayload(ctx, message, output);
+  } catch (error) {
+    replyWithError(ctx, message, error);
+  } finally {
+    channel.ack(message);
+  }
+}
+
+async function handleFeedRpc(
+  ctx: RpcContext,
+  route: CompiledRoute,
+  message: ConsumeMessage,
+  body: ScompTransportRequestEnvelope,
+): Promise<void> {
+  const rawPayload = body.payload;
+  const parsedPayload = route.parser ? route.parser(rawPayload) : rawPayload;
+  const hash = String(
+    body.feed ??
+      createFeedHash(route.route, parsedPayload, { hashKey: route.hashKey }),
+  );
+
+  const existing = ctx.runningFeeds.get(hash);
+  if (existing) {
+    existing.subscribers += 1;
+    ctx.emitEvent({ type: "feed_joined", route: route.route, hash });
+    replyWithPayload(ctx, message, {
+      exchange: existing.exchange,
+      feed: hash,
+    });
+    return;
+  }
+
+  const exchange = toFeedExchange(hash);
+  const channel = await ctx.getChannel();
+  await channel.assertExchange(exchange, "fanout", {
+    durable: false,
+    autoDelete: true,
+  });
+
+  const runningFeed: RunningFeed = {
+    key: hash,
+    exchange,
+    subscribers: 1,
+    abortController: new AbortController(),
+  };
+  ctx.runningFeeds.set(hash, runningFeed);
+  ctx.exchangeToFeedKey.set(exchange, hash);
+  ctx.emitEvent({ type: "feed_started", route: route.route, hash });
+
+  const iterable = route.handler(parsedPayload) as AsyncIterable<unknown>;
+  void publishFeed(
+    channel,
+    runningFeed,
+    iterable,
+    ctx.serializer,
+    ctx.contentType,
+    (feed) => {
+      ctx.runningFeeds.delete(feed.key);
+      ctx.exchangeToFeedKey.delete(feed.exchange);
+    },
+  );
+
+  replyWithPayload(ctx, message, { exchange, feed: hash });
+}
+
+function invokeRoute(
+  route: CompiledRoute,
+  body: ScompTransportRequestEnvelope,
+): Promise<unknown> {
+  const payload = route.parser ? route.parser(body.payload) : body.payload;
+  return route.handler(payload) as Promise<unknown>;
+}
+
+export function replyWithPayload(
+  ctx: RpcContext,
+  message: ConsumeMessage,
+  payload: unknown,
+): void {
+  const replyTo = message.properties.replyTo;
+  if (!replyTo) {
+    return;
+  }
+
+  ctx.getCurrentChannel()?.sendToQueue(
+    replyTo,
+    ctx.serializeToBuffer({
+      payload,
+    } satisfies ScompTransportResponseEnvelope),
+    {
+      correlationId: message.properties.correlationId,
+      contentType: ctx.contentType,
+    },
+  );
+}
+
+export function replyWithError(
+  ctx: RpcContext,
+  message: ConsumeMessage,
+  error: unknown,
+  code?: ScompErrorCode,
+): void {
+  const replyTo = message.properties.replyTo;
+  if (!replyTo) {
+    return;
+  }
+
+  ctx.getCurrentChannel()?.sendToQueue(
+    replyTo,
+    ctx.serializeToBuffer({
+      error: error instanceof Error ? error.message : String(error),
+      code,
+    } satisfies ScompTransportResponseEnvelope),
+    {
+      correlationId: message.properties.correlationId,
+      contentType: ctx.contentType,
+    },
+  );
+}

--- a/packages/transport-rabbitmq/src/types.ts
+++ b/packages/transport-rabbitmq/src/types.ts
@@ -1,0 +1,183 @@
+import type { CompiledRoute, ScompPriorityDecision } from "@scomp/core";
+import { resolveScompPriority } from "@scomp/core";
+import type {
+  ScompTransportMessageMeta,
+  ScompTransportPrincipal,
+  ScompTransportRequestEnvelope,
+  ScompTransportSecurityContext,
+  ScompTransportSecurityPolicy,
+} from "@scomp/types";
+
+export const SIGNAL_EXCHANGE = "scomp.signals";
+
+export class StreamClosedError extends Error {
+  constructor(streamHash: string) {
+    super(`Feed stream closed for hash: ${streamHash}`);
+    this.name = "StreamClosedError";
+  }
+}
+
+export interface RunningFeed {
+  key: string;
+  exchange: string;
+  subscribers: number;
+  abortController: AbortController;
+}
+
+export interface RabbitMQTransportRetryConfig {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export interface RabbitMQTransportSecurityConfig {
+  requireTls?: boolean;
+  maxPayloadBytes?: number;
+  policy?: ScompTransportSecurityPolicy;
+  authorize?: (ctx: {
+    direction: "inbound" | "outbound";
+    route: string;
+    operation: string;
+    payload: unknown;
+  }) => boolean | Promise<boolean>;
+}
+
+export interface RabbitMQTransportPerformanceConfig {
+  requestTimeoutMs?: number;
+  maxInFlightRequests?: number;
+  feedBufferHighWaterMark?: number;
+}
+
+export type RabbitMQTransportEvent =
+  | { type: "connection_opened" }
+  | { type: "connection_reconnect"; attempt: number }
+  | { type: "connection_closed"; reason?: string }
+  | { type: "channel_opened" }
+  | { type: "request_sent"; route: string; correlationId: string }
+  | {
+      type: "request_resolved";
+      route: string;
+      correlationId: string;
+      durationMs: number;
+    }
+  | {
+      type: "request_rejected";
+      route: string;
+      correlationId: string;
+      reason: string;
+    }
+  | {
+      type: "request_timeout";
+      route: string;
+      correlationId: string;
+      timeoutMs: number;
+    }
+  | { type: "signal_sent"; route: string }
+  | { type: "feed_started"; route: string; hash: string }
+  | { type: "feed_joined"; route: string; hash: string }
+  | { type: "feed_stopped"; route: string; hash: string }
+  | { type: "feed_aborted"; hash: string }
+  | { type: "publish_return"; exchange: string }
+  | {
+      type: "security_denied";
+      route: string;
+      operation: string;
+      direction: "inbound" | "outbound";
+    }
+  | {
+      type: "priority_decision";
+      direction: "inbound" | "outbound";
+      route: string;
+      operation: ScompTransportRequestEnvelope["op"];
+      source: ScompPriorityDecision["source"];
+      requested: ScompPriorityDecision["requested"];
+      effective: ScompPriorityDecision["effective"];
+    };
+
+export interface RabbitMQTransportObservabilityConfig {
+  onEvent?: (event: RabbitMQTransportEvent) => void;
+  now?: () => number;
+}
+
+export interface RabbitMQTransportConfig {
+  url: string;
+  prefetch?: number;
+  serviceName?: string;
+  serializer?: import("@scomp/types").ScompSerializer;
+  retry?: RabbitMQTransportRetryConfig;
+  security?: RabbitMQTransportSecurityConfig;
+  performance?: RabbitMQTransportPerformanceConfig;
+  observability?: RabbitMQTransportObservabilityConfig;
+}
+
+export type RouterTable = Record<string, CompiledRoute>;
+
+export function toServiceName(route: string): string {
+  const parts = route.split(".");
+  return parts[0] ?? "default";
+}
+
+export function toRpcQueue(serviceName: string): string {
+  return `scomp.rpc.${serviceName}`;
+}
+
+export function toFeedExchange(hash: string): string {
+  return `scomp.live.${hash}`;
+}
+
+export async function checkTransportSecurity(
+  security: RabbitMQTransportSecurityConfig | undefined,
+  ctx: Omit<ScompTransportSecurityContext, "principal">,
+): Promise<{ allowed: boolean; principal?: ScompTransportPrincipal }> {
+  const policy = security?.policy;
+
+  const principal = policy?.authenticate
+    ? await policy.authenticate(ctx)
+    : undefined;
+
+  if (policy?.authorize) {
+    const allowed = Boolean(
+      await policy.authorize({ ...ctx, principal: principal ?? undefined }),
+    );
+    return { allowed, principal: principal ?? undefined };
+  }
+
+  const legacyAuthorize = security?.authorize;
+  if (legacyAuthorize) {
+    const allowed = Boolean(
+      await legacyAuthorize({
+        direction: ctx.direction,
+        route: ctx.route,
+        operation: ctx.operation,
+        payload: ctx.payload,
+      }),
+    );
+    return { allowed, principal: principal ?? undefined };
+  }
+
+  return { allowed: true, principal: principal ?? undefined };
+}
+
+export function buildPriorityDecisionEvent(
+  direction: "inbound" | "outbound",
+  route: string,
+  operation: ScompTransportRequestEnvelope["op"],
+  meta?: ScompTransportMessageMeta,
+): Extract<RabbitMQTransportEvent, { type: "priority_decision" }> {
+  const decision = resolveScompPriority({
+    route,
+    operation,
+    meta: meta as
+      | (ScompTransportMessageMeta & Record<string, unknown>)
+      | undefined,
+  });
+  return {
+    type: "priority_decision",
+    direction,
+    route,
+    operation,
+    source: decision.source,
+    requested: decision.requested,
+    effective: decision.effective,
+  };
+}

--- a/packages/transport-rabbitmq/tsconfig.json
+++ b/packages/transport-rabbitmq/tsconfig.json
@@ -8,6 +8,7 @@
   },
   "references": [
     { "path": "../core" },
+    { "path": "../transport-shared" },
     { "path": "../types" }
   ],
   "include": ["src/**/*"]

--- a/packages/transport-shared/jest.config.cjs
+++ b/packages/transport-shared/jest.config.cjs
@@ -1,0 +1,5 @@
+const { createJestConfig } = require("../../jest.base.cjs");
+
+module.exports = createJestConfig({
+  rootDir: __dirname,
+});

--- a/packages/transport-shared/package.json
+++ b/packages/transport-shared/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@scomp/transport-shared",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "lint": "bunx tsc -b tsconfig.json --pretty false",
+    "test": "jest --config jest.config.cjs --passWithNoTests"
+  },
+  "dependencies": {
+    "@scomp/core": "workspace:*",
+    "@scomp/types": "workspace:*"
+  }
+}

--- a/packages/transport-shared/src/feed.ts
+++ b/packages/transport-shared/src/feed.ts
@@ -1,0 +1,16 @@
+import type {
+  ScompFeedChunkEnvelope,
+  ScompTransportRequestEnvelope,
+  ScompTransportResponseEnvelope,
+} from "@scomp/types";
+
+export type TransportMessage =
+  | ScompTransportRequestEnvelope
+  | ScompTransportResponseEnvelope
+  | ScompFeedChunkEnvelope;
+
+export function isFeedChunkEnvelope(
+  message: TransportMessage,
+): message is ScompFeedChunkEnvelope {
+  return (message as ScompFeedChunkEnvelope).channel === "feed";
+}

--- a/packages/transport-shared/src/index.ts
+++ b/packages/transport-shared/src/index.ts
@@ -1,0 +1,4 @@
+export { toPriorityMeta, toPrincipalMeta, mergeMeta } from "./meta";
+export { checkSecurity, type CheckSecurityResult } from "./security";
+export { safeJsonParse, type JsonParseResult } from "./parsing";
+export { isFeedChunkEnvelope, type TransportMessage } from "./feed";

--- a/packages/transport-shared/src/meta.ts
+++ b/packages/transport-shared/src/meta.ts
@@ -1,0 +1,74 @@
+import type { ScompClientInvokeOptions } from "@scomp/core";
+import type {
+  ScompTransportMessageMeta,
+  ScompTransportPrincipal,
+} from "@scomp/types";
+
+export function toPriorityMeta(
+  options?: ScompClientInvokeOptions,
+): ScompTransportMessageMeta | undefined {
+  if (!options) {
+    return undefined;
+  }
+
+  const { priority, priorityClass, deadlineAtMs, targetLatencyMs } = options;
+  if (
+    priority === undefined &&
+    priorityClass === undefined &&
+    deadlineAtMs === undefined &&
+    targetLatencyMs === undefined
+  ) {
+    return undefined;
+  }
+
+  const meta: ScompTransportMessageMeta = {};
+  if (priority !== undefined) {
+    meta.priority = priority;
+  }
+  if (priorityClass !== undefined) {
+    meta.priorityClass = priorityClass;
+  }
+  if (deadlineAtMs !== undefined) {
+    meta.deadlineAtMs = deadlineAtMs;
+  }
+  if (targetLatencyMs !== undefined) {
+    meta.targetLatencyMs = targetLatencyMs;
+  }
+
+  return meta;
+}
+
+export function toPrincipalMeta(
+  principal: ScompTransportPrincipal | undefined,
+): ScompTransportMessageMeta | undefined {
+  if (!principal) {
+    return undefined;
+  }
+
+  return {
+    auth: {
+      subject: principal.subject,
+      tenantId: principal.tenantId,
+      scopes: principal.scopes,
+      claims: principal.claims,
+      issuedAt: principal.issuedAt,
+      expiresAt: principal.expiresAt,
+      authType: principal.authType,
+    },
+    tenantId: principal.tenantId,
+  };
+}
+
+export function mergeMeta(
+  baseMeta: ScompTransportMessageMeta | undefined,
+  overlayMeta: ScompTransportMessageMeta | undefined,
+): ScompTransportMessageMeta | undefined {
+  if (!baseMeta && !overlayMeta) {
+    return undefined;
+  }
+
+  return {
+    ...(baseMeta ?? {}),
+    ...(overlayMeta ?? {}),
+  };
+}

--- a/packages/transport-shared/src/parsing.ts
+++ b/packages/transport-shared/src/parsing.ts
@@ -1,0 +1,15 @@
+export type JsonParseResult =
+  | { ok: true; value: unknown }
+  | { ok: false; error: string; raw: string };
+
+export function safeJsonParse(text: string): JsonParseResult {
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      raw: text.length > 200 ? text.slice(0, 200) + "…" : text,
+    };
+  }
+}

--- a/packages/transport-shared/src/security.ts
+++ b/packages/transport-shared/src/security.ts
@@ -1,0 +1,36 @@
+import type {
+  ScompTransportPrincipal,
+  ScompTransportSecurityContext,
+  ScompTransportSecurityPolicy,
+} from "@scomp/types";
+
+export interface CheckSecurityResult {
+  allowed: boolean;
+  principal?: ScompTransportPrincipal;
+}
+
+export async function checkSecurity(
+  policy: ScompTransportSecurityPolicy | undefined,
+  ctx: Omit<ScompTransportSecurityContext, "principal">,
+): Promise<CheckSecurityResult> {
+  if (!policy) {
+    return { allowed: true };
+  }
+
+  const principal = policy.authenticate
+    ? await policy.authenticate(ctx)
+    : undefined;
+
+  if (!policy.authorize) {
+    return { allowed: true, principal: principal ?? undefined };
+  }
+
+  const allowed = Boolean(
+    await policy.authorize({
+      ...ctx,
+      principal: principal ?? undefined,
+    }),
+  );
+
+  return { allowed, principal: principal ?? undefined };
+}

--- a/packages/transport-shared/test/parsing.spec.ts
+++ b/packages/transport-shared/test/parsing.spec.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { safeJsonParse, type JsonParseResult } from "../src/parsing";
+
+describe("safeJsonParse", () => {
+  it("returns ok result for valid JSON", () => {
+    const result = safeJsonParse('{"key":"value"}');
+    assert.equal(result.ok, true);
+    assert.deepEqual((result as Extract<JsonParseResult, { ok: true }>).value, {
+      key: "value",
+    });
+  });
+
+  it("returns ok result for JSON primitives", () => {
+    assert.deepEqual(safeJsonParse("42"), { ok: true, value: 42 });
+    assert.deepEqual(safeJsonParse('"hello"'), { ok: true, value: "hello" });
+    assert.deepEqual(safeJsonParse("null"), { ok: true, value: null });
+    assert.deepEqual(safeJsonParse("true"), { ok: true, value: true });
+  });
+
+  it("returns ok result for JSON arrays", () => {
+    const result = safeJsonParse("[1,2,3]");
+    assert.equal(result.ok, true);
+    assert.deepEqual(
+      (result as Extract<JsonParseResult, { ok: true }>).value,
+      [1, 2, 3],
+    );
+  });
+
+  it("returns error result for invalid JSON", () => {
+    const result = safeJsonParse("not json");
+    assert.equal(result.ok, false);
+    const err = result as Extract<JsonParseResult, { ok: false }>;
+    assert.equal(typeof err.error, "string");
+    assert.ok(err.error.length > 0);
+    assert.equal(err.raw, "not json");
+  });
+
+  it("returns error result for empty string", () => {
+    const result = safeJsonParse("");
+    assert.equal(result.ok, false);
+    const err = result as Extract<JsonParseResult, { ok: false }>;
+    assert.equal(err.raw, "");
+  });
+
+  it("truncates raw field to 200 characters on failure", () => {
+    const longText = "x".repeat(300);
+    const result = safeJsonParse(longText);
+    assert.equal(result.ok, false);
+    const err = result as Extract<JsonParseResult, { ok: false }>;
+    assert.equal(err.raw.length, 201); // 200 chars + ellipsis character
+    assert.ok(err.raw.endsWith("…"));
+  });
+
+  it("preserves raw field when input is 200 chars or fewer", () => {
+    const shortText = "y".repeat(200);
+    const result = safeJsonParse(shortText);
+    assert.equal(result.ok, false);
+    const err = result as Extract<JsonParseResult, { ok: false }>;
+    assert.equal(err.raw, shortText);
+    assert.equal(err.raw.length, 200);
+  });
+});

--- a/packages/transport-shared/tsconfig.json
+++ b/packages/transport-shared/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "references": [{ "path": "../core" }, { "path": "../types" }],
+  "include": ["src/**/*"]
+}

--- a/packages/transport-websocket-browser/package.json
+++ b/packages/transport-websocket-browser/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@scomp/core": "workspace:*",
+    "@scomp/transport-shared": "workspace:*",
     "@scomp/types": "workspace:*"
   }
 }

--- a/packages/transport-websocket-browser/src/index.ts
+++ b/packages/transport-websocket-browser/src/index.ts
@@ -9,135 +9,30 @@ import type {
   ScompTransportMessageMeta,
   ScompTransportOperation,
   ScompTransportPrincipal,
-  ScompTransportSecurityContext,
-  ScompTransportSecurityPolicy,
   ScompTransportRequestEnvelope,
   ScompTransportResponseEnvelope,
 } from "@scomp/types";
-
-export class SocketDisconnectedError extends Error {
-  constructor(message = "WebSocket connection closed.") {
-    super(message);
-    this.name = "SocketDisconnectedError";
-  }
-}
-
-interface PendingRequest {
-  resolve: (value: unknown) => void;
-  reject: (error: unknown) => void;
-}
-
-interface FeedState {
-  queue: Array<unknown | Promise<never>>;
-  waiters: Array<() => void>;
-  closed: boolean;
-  terminalError?: Error;
-}
-
-function toDisconnectError(error: unknown): Error {
-  if (error instanceof Error) {
-    return error;
-  }
-
-  const message =
-    typeof error === "string" && error.length > 0
-      ? error
-      : "WebSocket connection closed.";
-  return new SocketDisconnectedError(message);
-}
-
-type BrowserSocket = Pick<
-  WebSocket,
-  "send" | "close" | "addEventListener" | "removeEventListener" | "readyState"
->;
-
-type BrowserWebSocketCtor = new (
-  url: string,
-  protocols?: string | Array<string>,
-) => BrowserSocket;
-
-type TransportMessage =
-  | ScompTransportRequestEnvelope
-  | ScompTransportResponseEnvelope
-  | ScompFeedChunkEnvelope;
-
-export interface WebSocketBrowserTransportConfig {
-  url: string;
-  protocols?: string | Array<string>;
-  meta?:
-    | ScompTransportMessageMeta
-    | (() => ScompTransportMessageMeta | Promise<ScompTransportMessageMeta>);
-  security?: ScompTransportSecurityPolicy;
-  webSocketCtor?: BrowserWebSocketCtor;
-}
-
-function toPriorityMeta(
-  options?: ScompClientInvokeOptions,
-): ScompTransportMessageMeta | undefined {
-  if (!options) {
-    return undefined;
-  }
-
-  const { priority, priorityClass, deadlineAtMs, targetLatencyMs } = options;
-  if (
-    priority === undefined &&
-    priorityClass === undefined &&
-    deadlineAtMs === undefined &&
-    targetLatencyMs === undefined
-  ) {
-    return undefined;
-  }
-
-  const meta: ScompTransportMessageMeta = {};
-  if (priority !== undefined) {
-    meta.priority = priority;
-  }
-  if (priorityClass !== undefined) {
-    meta.priorityClass = priorityClass;
-  }
-  if (deadlineAtMs !== undefined) {
-    meta.deadlineAtMs = deadlineAtMs;
-  }
-  if (targetLatencyMs !== undefined) {
-    meta.targetLatencyMs = targetLatencyMs;
-  }
-
-  return meta;
-}
-
-function safeJsonParse(text: string): any {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return {};
-  }
-}
-
-function isFeedChunkEnvelope(
-  message: TransportMessage,
-): message is ScompFeedChunkEnvelope {
-  return (message as ScompFeedChunkEnvelope).channel === "feed";
-}
-
-async function toText(data: unknown): Promise<string> {
-  if (typeof data === "string") {
-    return data;
-  }
-
-  if (data instanceof ArrayBuffer) {
-    return new TextDecoder().decode(data);
-  }
-
-  if (ArrayBuffer.isView(data)) {
-    return new TextDecoder().decode(data);
-  }
-
-  if (typeof Blob !== "undefined" && data instanceof Blob) {
-    return data.text();
-  }
-
-  return String(data ?? "");
-}
+import {
+  toPriorityMeta,
+  toPrincipalMeta,
+  mergeMeta,
+  safeJsonParse,
+  isFeedChunkEnvelope,
+  checkSecurity,
+  type TransportMessage,
+} from "@scomp/transport-shared";
+import {
+  SocketDisconnectedError,
+  toText,
+  enqueueFeedChunk,
+  drainPendingFeedChunks,
+  handleDisconnect,
+  type BrowserSocket,
+  type BrowserWebSocketCtor,
+  type FeedState,
+  type PendingRequest,
+  type WebSocketBrowserTransportConfig,
+} from "./types";
 
 export class WebSocketBrowserTransport implements ITransport {
   private readonly config: WebSocketBrowserTransportConfig;
@@ -161,22 +56,16 @@ export class WebSocketBrowserTransport implements ITransport {
 
   async close(): Promise<void> {
     const socket = this.socket;
-    this.handleDisconnect(
+    this.onDisconnect(
       new SocketDisconnectedError("WebSocket transport closed."),
     );
 
-    if (!socket) {
-      return;
-    }
-
-    if (socket.readyState >= 2) {
-      return;
-    }
-
+    if (!socket) return;
+    if (socket.readyState >= 2) return;
     try {
       socket.close();
     } catch {
-      // no-op
+      /* no-op */
     }
   }
 
@@ -196,9 +85,9 @@ export class WebSocketBrowserTransport implements ITransport {
     const socket = await this.getSocket();
     const operation: ScompTransportOperation = "signal";
     const priorityMeta = toPriorityMeta(options);
-    const baseMeta = this.mergeMeta(await this.resolveMeta(), options?.meta);
-    const effectiveMeta = this.mergeMeta(baseMeta, priorityMeta);
-    const { allowed, principal } = await this.checkSecurity({
+    const baseMeta = mergeMeta(await this.resolveMeta(), options?.meta);
+    const effectiveMeta = mergeMeta(baseMeta, priorityMeta);
+    const { allowed, principal } = await checkSecurity(this.config.security, {
       direction: "outbound",
       transport: "websocket",
       route,
@@ -206,23 +95,16 @@ export class WebSocketBrowserTransport implements ITransport {
       payload,
       meta: effectiveMeta,
     });
-    if (!allowed) {
-      throw new Error(`signal not authorized for route: ${route}`);
-    }
+    if (!allowed) throw new Error(`signal not authorized for route: ${route}`);
 
     const envelope: Record<string, unknown> = {
       route,
       op: "signal",
       payload,
-      meta: this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal)),
+      meta: mergeMeta(effectiveMeta, toPrincipalMeta(principal)),
     };
-
-    if (options?.feed) {
-      envelope.feed = options.feed;
-    }
-    if (options?.method) {
-      envelope.method = options.method;
-    }
+    if (options?.feed) envelope.feed = options.feed;
+    if (options?.method) envelope.method = options.method;
 
     this.sendJson(socket, envelope);
   }
@@ -238,12 +120,10 @@ export class WebSocketBrowserTransport implements ITransport {
       async *[Symbol.asyncIterator]() {
         const handshake = await self.sendRpc(route, "feed", payload, options);
         const feedHash = String(handshake?.feed ?? "");
-
-        if (!feedHash) {
+        if (!feedHash)
           throw new Error(
             "Feed start response did not include a feed identifier.",
           );
-        }
 
         const state: FeedState = {
           queue: [],
@@ -251,7 +131,6 @@ export class WebSocketBrowserTransport implements ITransport {
           closed: false,
           terminalError: undefined,
         };
-
         self.feeds.set(feedHash, state);
         if (!self.socket || !self.isOpen(self.socket)) {
           state.closed = true;
@@ -262,34 +141,22 @@ export class WebSocketBrowserTransport implements ITransport {
           );
         }
 
-        self.drainPendingFeedChunks(feedHash, state);
+        drainPendingFeedChunks(feedHash, state, self.pendingFeedChunks);
 
         try {
           while (true) {
             if (state.queue.length > 0) {
               const value = state.queue.shift();
-              if (value instanceof Promise) {
-                await value;
-              }
-
+              if (value instanceof Promise) await value;
               if (state.closed && value === undefined) {
-                const terminalError =
-                  state.terminalError ?? self.lastDisconnectError;
-                if (terminalError) {
-                  throw terminalError;
-                }
+                if (state.terminalError ?? self.lastDisconnectError)
+                  throw state.terminalError ?? self.lastDisconnectError;
                 return;
               }
-
-              if (value !== undefined) {
-                yield value;
-              }
+              if (value !== undefined) yield value;
             } else if (state.closed) {
-              const terminalError =
-                state.terminalError ?? self.lastDisconnectError;
-              if (terminalError) {
-                throw terminalError;
-              }
+              if (state.terminalError ?? self.lastDisconnectError)
+                throw state.terminalError ?? self.lastDisconnectError;
               return;
             } else {
               await new Promise<void>((resolve) => state.waiters.push(resolve));
@@ -299,10 +166,7 @@ export class WebSocketBrowserTransport implements ITransport {
           self.feeds.delete(feedHash);
           self.pendingFeedChunks.delete(feedHash);
           const activeSocket = self.socket;
-          if (!activeSocket || !self.isOpen(activeSocket)) {
-            return;
-          }
-
+          if (!activeSocket || !self.isOpen(activeSocket)) return;
           try {
             self.sendJson(activeSocket, {
               route,
@@ -312,9 +176,7 @@ export class WebSocketBrowserTransport implements ITransport {
               payload: {},
             });
           } catch (error) {
-            if (!(error instanceof SocketDisconnectedError)) {
-              throw error;
-            }
+            if (!(error instanceof SocketDisconnectedError)) throw error;
           }
         }
       },
@@ -322,16 +184,12 @@ export class WebSocketBrowserTransport implements ITransport {
   }
 
   private resolveWebSocketCtor(): BrowserWebSocketCtor {
-    if (this.config.webSocketCtor) {
-      return this.config.webSocketCtor;
-    }
-
+    if (this.config.webSocketCtor) return this.config.webSocketCtor;
     if (typeof globalThis.WebSocket !== "function") {
       throw new Error(
         "No WebSocket constructor found. Provide config.webSocketCtor in non-browser environments.",
       );
     }
-
     return globalThis.WebSocket as unknown as BrowserWebSocketCtor;
   }
 
@@ -341,13 +199,8 @@ export class WebSocketBrowserTransport implements ITransport {
   }
 
   private async getSocket(): Promise<BrowserSocket> {
-    if (this.socket && this.isOpen(this.socket)) {
-      return this.socket;
-    }
-
-    if (this.openingPromise) {
-      return this.openingPromise;
-    }
+    if (this.socket && this.isOpen(this.socket)) return this.socket;
+    if (this.openingPromise) return this.openingPromise;
 
     this.openingPromise = new Promise<BrowserSocket>((resolve, reject) => {
       const WebSocketCtor = this.resolveWebSocketCtor();
@@ -361,13 +214,11 @@ export class WebSocketBrowserTransport implements ITransport {
         this.openingPromise = undefined;
         resolve(socket);
       };
-
       const onError = (event: Event) => {
         cleanup();
         this.openingPromise = undefined;
         reject(event);
       };
-
       const cleanup = () => {
         socket.removeEventListener("open", onOpen as EventListener);
         socket.removeEventListener("error", onError as EventListener);
@@ -385,20 +236,15 @@ export class WebSocketBrowserTransport implements ITransport {
   private attachSocketHandlers(socket: BrowserSocket): void {
     socket.addEventListener("message", (event: MessageEvent) => {
       void (async () => {
-        const message = safeJsonParse(
-          await toText(event.data),
-        ) as TransportMessage;
-        this.handleIncoming(message);
+        const parsed = safeJsonParse(await toText(event.data));
+        if (!parsed.ok) return;
+        this.handleIncoming(parsed.value as TransportMessage);
       })();
     });
-
-    socket.addEventListener("close", () => {
-      this.handleDisconnect(new SocketDisconnectedError());
-    });
-
-    socket.addEventListener("error", (event) => {
-      this.handleDisconnect(event);
-    });
+    socket.addEventListener("close", () =>
+      this.onDisconnect(new SocketDisconnectedError()),
+    );
+    socket.addEventListener("error", (event) => this.onDisconnect(event));
   }
 
   private handleIncoming(message: TransportMessage): void {
@@ -411,21 +257,14 @@ export class WebSocketBrowserTransport implements ITransport {
         this.pendingFeedChunks.set(feedId, pending);
         return;
       }
-
-      this.enqueueFeedChunk(feed, message);
+      enqueueFeedChunk(feed, message);
       return;
     }
 
     const id = String((message as ScompTransportResponseEnvelope).id ?? "");
-    if (!id) {
-      return;
-    }
-
+    if (!id) return;
     const pending = this.pendingRequests.get(id);
-    if (!pending) {
-      return;
-    }
-
+    if (!pending) return;
     this.pendingRequests.delete(id);
 
     if (
@@ -436,36 +275,22 @@ export class WebSocketBrowserTransport implements ITransport {
       pending.reject(new Error(message.error));
       return;
     }
-
     if ("payload" in message) {
       pending.resolve(message.payload);
       return;
     }
-
     pending.resolve(undefined);
   }
 
-  private handleDisconnect(error: unknown): void {
+  private onDisconnect(error: unknown): void {
     this.socket = undefined;
-    const disconnectError = toDisconnectError(error);
+    const { disconnectError } = handleDisconnect(
+      this.pendingRequests,
+      this.feeds,
+      this.pendingFeedChunks,
+      error,
+    );
     this.lastDisconnectError = disconnectError;
-
-    for (const pending of this.pendingRequests.values()) {
-      pending.reject(disconnectError);
-    }
-    this.pendingRequests.clear();
-
-    this.pendingFeedChunks.clear();
-
-    for (const feed of this.feeds.values()) {
-      feed.closed = true;
-      feed.terminalError = disconnectError;
-      feed.queue.push(Promise.reject(disconnectError));
-      while (feed.waiters.length > 0) {
-        const waiter = feed.waiters.shift();
-        waiter?.();
-      }
-    }
   }
 
   private async sendRpc(
@@ -476,9 +301,9 @@ export class WebSocketBrowserTransport implements ITransport {
   ): Promise<any> {
     const socket = await this.getSocket();
     const priorityMeta = toPriorityMeta(options);
-    const baseMeta = this.mergeMeta(await this.resolveMeta(), options?.meta);
-    const effectiveMeta = this.mergeMeta(baseMeta, priorityMeta);
-    const { allowed, principal } = await this.checkSecurity({
+    const baseMeta = mergeMeta(await this.resolveMeta(), options?.meta);
+    const effectiveMeta = mergeMeta(baseMeta, priorityMeta);
+    const { allowed, principal } = await checkSecurity(this.config.security, {
       direction: "outbound",
       transport: "websocket",
       route,
@@ -486,9 +311,7 @@ export class WebSocketBrowserTransport implements ITransport {
       payload,
       meta: effectiveMeta,
     });
-    if (!allowed) {
-      throw new Error(`${op} not authorized for route: ${route}`);
-    }
+    if (!allowed) throw new Error(`${op} not authorized for route: ${route}`);
     const id = randomUUID();
 
     const response = new Promise<unknown>((resolve, reject) => {
@@ -496,7 +319,6 @@ export class WebSocketBrowserTransport implements ITransport {
     });
 
     const outboundMeta = await this.composeOutboundMeta(options, principal);
-
     const envelope: ScompTransportRequestEnvelope = {
       id,
       route,
@@ -504,88 +326,22 @@ export class WebSocketBrowserTransport implements ITransport {
       payload,
       meta: outboundMeta,
     };
-
-    if (options?.feed) {
-      envelope.feed = options.feed;
-    }
-    if (options?.method) {
-      envelope.method = options.method;
-    }
+    if (options?.feed) envelope.feed = options.feed;
+    if (options?.method) envelope.method = options.method;
 
     this.sendJson(socket, envelope);
-
     return response;
   }
 
-  private drainPendingFeedChunks(hash: string, feed: FeedState): void {
-    const pending = this.pendingFeedChunks.get(hash);
-    if (!pending || pending.length === 0) {
-      return;
-    }
-
-    this.pendingFeedChunks.delete(hash);
-    for (const message of pending) {
-      this.enqueueFeedChunk(feed, message);
-    }
-  }
-
-  private enqueueFeedChunk(
-    feed: FeedState,
-    message: ScompFeedChunkEnvelope,
-  ): void {
-    if (message.type === "done") {
-      feed.closed = true;
-      feed.terminalError = undefined;
-    } else if (message.type === "error") {
-      feed.closed = true;
-      const error = new Error(String(message.message ?? "Feed error"));
-      feed.terminalError = error;
-      feed.queue.push(Promise.reject(error));
-    } else {
-      feed.queue.push(message.payload);
-    }
-
-    const waiter = feed.waiters.shift();
-    waiter?.();
-  }
-
   private sendJson(socket: BrowserSocket, payload: unknown): void {
-    const serialized = JSON.stringify(payload);
-    socket.send(serialized);
+    socket.send(JSON.stringify(payload));
   }
 
   private async resolveMeta(): Promise<ScompTransportMessageMeta | undefined> {
     const metaConfig = this.config.meta;
-    if (!metaConfig) {
-      return undefined;
-    }
-
-    if (typeof metaConfig === "function") {
-      return metaConfig();
-    }
-
+    if (!metaConfig) return undefined;
+    if (typeof metaConfig === "function") return metaConfig();
     return metaConfig;
-  }
-
-  private toPrincipalMeta(
-    principal: ScompTransportPrincipal | undefined,
-  ): ScompTransportMessageMeta | undefined {
-    if (!principal) {
-      return undefined;
-    }
-
-    return {
-      auth: {
-        subject: principal.subject,
-        tenantId: principal.tenantId,
-        scopes: principal.scopes,
-        claims: principal.claims,
-        issuedAt: principal.issuedAt,
-        expiresAt: principal.expiresAt,
-        authType: principal.authType,
-      },
-      tenantId: principal.tenantId,
-    };
   }
 
   /**
@@ -597,49 +353,9 @@ export class WebSocketBrowserTransport implements ITransport {
     principal: ScompTransportPrincipal | undefined,
   ): Promise<ScompTransportMessageMeta | undefined> {
     const priorityMeta = toPriorityMeta(options);
-    const baseMeta = this.mergeMeta(await this.resolveMeta(), options?.meta);
-    const effectiveMeta = this.mergeMeta(baseMeta, priorityMeta);
-    return this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal));
-  }
-
-  private mergeMeta(
-    baseMeta: ScompTransportMessageMeta | undefined,
-    overlayMeta: ScompTransportMessageMeta | undefined,
-  ): ScompTransportMessageMeta | undefined {
-    if (!baseMeta && !overlayMeta) {
-      return undefined;
-    }
-
-    return {
-      ...(baseMeta ?? {}),
-      ...(overlayMeta ?? {}),
-    };
-  }
-
-  private async checkSecurity(
-    ctx: Omit<ScompTransportSecurityContext, "principal">,
-  ): Promise<{ allowed: boolean; principal?: ScompTransportPrincipal }> {
-    const policy = this.config.security;
-    if (!policy) {
-      return { allowed: true };
-    }
-
-    const principal = policy.authenticate
-      ? await policy.authenticate(ctx)
-      : undefined;
-
-    if (!policy.authorize) {
-      return { allowed: true, principal: principal ?? undefined };
-    }
-
-    const allowed = Boolean(
-      await policy.authorize({
-        ...ctx,
-        principal: principal ?? undefined,
-      }),
-    );
-
-    return { allowed, principal: principal ?? undefined };
+    const baseMeta = mergeMeta(await this.resolveMeta(), options?.meta);
+    const effectiveMeta = mergeMeta(baseMeta, priorityMeta);
+    return mergeMeta(effectiveMeta, toPrincipalMeta(principal));
   }
 }
 
@@ -648,3 +364,8 @@ export function createWebSocketBrowserTransport(
 ): WebSocketBrowserTransport {
   return new WebSocketBrowserTransport(config);
 }
+
+export {
+  SocketDisconnectedError,
+  type WebSocketBrowserTransportConfig,
+} from "./types";

--- a/packages/transport-websocket-browser/src/types.ts
+++ b/packages/transport-websocket-browser/src/types.ts
@@ -1,0 +1,140 @@
+import type {
+  ScompFeedChunkEnvelope,
+  ScompTransportMessageMeta,
+  ScompTransportSecurityPolicy,
+} from "@scomp/types";
+
+export class SocketDisconnectedError extends Error {
+  constructor(message = "WebSocket connection closed.") {
+    super(message);
+    this.name = "SocketDisconnectedError";
+  }
+}
+
+export interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+}
+
+export interface FeedState {
+  queue: Array<unknown | Promise<never>>;
+  waiters: Array<() => void>;
+  closed: boolean;
+  terminalError?: Error;
+}
+
+export function toDisconnectError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  const message =
+    typeof error === "string" && error.length > 0
+      ? error
+      : "WebSocket connection closed.";
+  return new SocketDisconnectedError(message);
+}
+
+export type BrowserSocket = Pick<
+  WebSocket,
+  "send" | "close" | "addEventListener" | "removeEventListener" | "readyState"
+>;
+
+export type BrowserWebSocketCtor = new (
+  url: string,
+  protocols?: string | Array<string>,
+) => BrowserSocket;
+
+export interface WebSocketBrowserTransportConfig {
+  url: string;
+  protocols?: string | Array<string>;
+  meta?:
+    | ScompTransportMessageMeta
+    | (() => ScompTransportMessageMeta | Promise<ScompTransportMessageMeta>);
+  security?: ScompTransportSecurityPolicy;
+  webSocketCtor?: BrowserWebSocketCtor;
+}
+
+export async function toText(data: unknown): Promise<string> {
+  if (typeof data === "string") {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data);
+  }
+
+  if (typeof Blob !== "undefined" && data instanceof Blob) {
+    return data.text();
+  }
+
+  return String(data ?? "");
+}
+
+export function enqueueFeedChunk(
+  feed: FeedState,
+  message: ScompFeedChunkEnvelope,
+): void {
+  if (message.type === "done") {
+    feed.closed = true;
+    feed.terminalError = undefined;
+  } else if (message.type === "error") {
+    feed.closed = true;
+    const error = new Error(String(message.message ?? "Feed error"));
+    feed.terminalError = error;
+    feed.queue.push(Promise.reject(error));
+  } else {
+    feed.queue.push(message.payload);
+  }
+
+  const waiter = feed.waiters.shift();
+  waiter?.();
+}
+
+export function drainPendingFeedChunks(
+  hash: string,
+  feed: FeedState,
+  pendingFeedChunks: Map<string, Array<ScompFeedChunkEnvelope>>,
+): void {
+  const pending = pendingFeedChunks.get(hash);
+  if (!pending || pending.length === 0) {
+    return;
+  }
+
+  pendingFeedChunks.delete(hash);
+  for (const message of pending) {
+    enqueueFeedChunk(feed, message);
+  }
+}
+
+export function handleDisconnect(
+  pendingRequests: Map<string, PendingRequest>,
+  feeds: Map<string, FeedState>,
+  pendingFeedChunks: Map<string, Array<ScompFeedChunkEnvelope>>,
+  error: unknown,
+): { disconnectError: Error } {
+  const disconnectError = toDisconnectError(error);
+
+  for (const pending of pendingRequests.values()) {
+    pending.reject(disconnectError);
+  }
+  pendingRequests.clear();
+
+  pendingFeedChunks.clear();
+
+  for (const feed of feeds.values()) {
+    feed.closed = true;
+    feed.terminalError = disconnectError;
+    feed.queue.push(Promise.reject(disconnectError));
+    while (feed.waiters.length > 0) {
+      const waiter = feed.waiters.shift();
+      waiter?.();
+    }
+  }
+
+  return { disconnectError };
+}

--- a/packages/transport-websocket-browser/tsconfig.json
+++ b/packages/transport-websocket-browser/tsconfig.json
@@ -9,6 +9,7 @@
   },
   "references": [
     { "path": "../core" },
+    { "path": "../transport-shared" },
     { "path": "../types" }
   ],
   "include": ["src/**/*"]

--- a/packages/transport-websocket-client/package.json
+++ b/packages/transport-websocket-client/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@scomp/core": "workspace:*",
+    "@scomp/transport-shared": "workspace:*",
     "@scomp/types": "workspace:*",
     "@types/ws": "^8.18.1",
     "ws": "^8.18.3"

--- a/packages/transport-websocket-client/src/index.ts
+++ b/packages/transport-websocket-client/src/index.ts
@@ -9,11 +9,19 @@ import type {
   ScompTransportMessageMeta,
   ScompTransportOperation,
   ScompTransportPrincipal,
-  ScompTransportSecurityContext,
-  ScompTransportSecurityPolicy,
   ScompTransportRequestEnvelope,
   ScompTransportResponseEnvelope,
+  ScompTransportSecurityPolicy,
 } from "@scomp/types";
+import {
+  toPriorityMeta,
+  toPrincipalMeta,
+  mergeMeta,
+  safeJsonParse,
+  isFeedChunkEnvelope,
+  checkSecurity,
+  type TransportMessage,
+} from "@scomp/transport-shared";
 import WebSocket, { type RawData } from "ws";
 
 export class SocketDisconnectedError extends Error {
@@ -34,11 +42,6 @@ interface FeedState {
   closed: boolean;
 }
 
-type TransportMessage =
-  | ScompTransportRequestEnvelope
-  | ScompTransportResponseEnvelope
-  | ScompFeedChunkEnvelope;
-
 export interface WebSocketClientTransportConfig {
   url: string;
   protocols?: string | Array<string>;
@@ -46,48 +49,6 @@ export interface WebSocketClientTransportConfig {
     | ScompTransportMessageMeta
     | (() => ScompTransportMessageMeta | Promise<ScompTransportMessageMeta>);
   security?: ScompTransportSecurityPolicy;
-}
-
-function toPriorityMeta(
-  options?: ScompClientInvokeOptions,
-): ScompTransportMessageMeta | undefined {
-  if (!options) {
-    return undefined;
-  }
-
-  const { priority, priorityClass, deadlineAtMs, targetLatencyMs } = options;
-  if (
-    priority === undefined &&
-    priorityClass === undefined &&
-    deadlineAtMs === undefined &&
-    targetLatencyMs === undefined
-  ) {
-    return undefined;
-  }
-
-  const meta: ScompTransportMessageMeta = {};
-  if (priority !== undefined) {
-    meta.priority = priority;
-  }
-  if (priorityClass !== undefined) {
-    meta.priorityClass = priorityClass;
-  }
-  if (deadlineAtMs !== undefined) {
-    meta.deadlineAtMs = deadlineAtMs;
-  }
-  if (targetLatencyMs !== undefined) {
-    meta.targetLatencyMs = targetLatencyMs;
-  }
-
-  return meta;
-}
-
-function safeJsonParse(text: string): any {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return {};
-  }
 }
 
 function toText(data: RawData): string {
@@ -104,12 +65,6 @@ function toText(data: RawData): string {
   }
 
   return Buffer.from(data).toString("utf8");
-}
-
-function isFeedChunkEnvelope(
-  message: TransportMessage,
-): message is ScompFeedChunkEnvelope {
-  return (message as ScompFeedChunkEnvelope).channel === "feed";
 }
 
 export class WebSocketClientTransport implements ITransport {
@@ -188,9 +143,9 @@ export class WebSocketClientTransport implements ITransport {
     const socket = await this.getSocket();
     const operation: ScompTransportOperation = "signal";
     const priorityMeta = toPriorityMeta(options);
-    const baseMeta = this.mergeMeta(await this.resolveMeta(), options?.meta);
-    const effectiveMeta = this.mergeMeta(baseMeta, priorityMeta);
-    const { allowed, principal } = await this.checkSecurity({
+    const baseMeta = mergeMeta(await this.resolveMeta(), options?.meta);
+    const effectiveMeta = mergeMeta(baseMeta, priorityMeta);
+    const { allowed, principal } = await checkSecurity(this.config.security, {
       direction: "outbound",
       transport: "websocket",
       route,
@@ -205,7 +160,7 @@ export class WebSocketClientTransport implements ITransport {
       route,
       op: "signal",
       payload,
-      meta: this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal)),
+      meta: mergeMeta(effectiveMeta, toPrincipalMeta(principal)),
     };
 
     if (options?.feed) {
@@ -321,7 +276,11 @@ export class WebSocketClientTransport implements ITransport {
 
   private attachSocketHandlers(socket: WebSocket): void {
     socket.on("message", (data: RawData) => {
-      const message = safeJsonParse(toText(data)) as TransportMessage;
+      const parsed = safeJsonParse(toText(data));
+      if (!parsed.ok) {
+        return;
+      }
+      const message = parsed.value as TransportMessage;
       this.handleIncoming(message);
     });
 
@@ -412,9 +371,9 @@ export class WebSocketClientTransport implements ITransport {
   ): Promise<any> {
     const socket = await this.getSocket();
     const priorityMeta = toPriorityMeta(options);
-    const baseMeta = this.mergeMeta(await this.resolveMeta(), options?.meta);
-    const effectiveMeta = this.mergeMeta(baseMeta, priorityMeta);
-    const { allowed, principal } = await this.checkSecurity({
+    const baseMeta = mergeMeta(await this.resolveMeta(), options?.meta);
+    const effectiveMeta = mergeMeta(baseMeta, priorityMeta);
+    const { allowed, principal } = await checkSecurity(this.config.security, {
       direction: "outbound",
       transport: "websocket",
       route,
@@ -436,7 +395,7 @@ export class WebSocketClientTransport implements ITransport {
       route,
       op,
       payload,
-      meta: this.mergeMeta(effectiveMeta, this.toPrincipalMeta(principal)),
+      meta: mergeMeta(effectiveMeta, toPrincipalMeta(principal)),
     };
 
     if (options?.feed) {
@@ -498,67 +457,6 @@ export class WebSocketClientTransport implements ITransport {
     }
 
     return metaConfig;
-  }
-
-  private toPrincipalMeta(
-    principal: ScompTransportPrincipal | undefined,
-  ): ScompTransportMessageMeta | undefined {
-    if (!principal) {
-      return undefined;
-    }
-
-    return {
-      auth: {
-        subject: principal.subject,
-        tenantId: principal.tenantId,
-        scopes: principal.scopes,
-        claims: principal.claims,
-        issuedAt: principal.issuedAt,
-        expiresAt: principal.expiresAt,
-        authType: principal.authType,
-      },
-      tenantId: principal.tenantId,
-    };
-  }
-
-  private mergeMeta(
-    baseMeta: ScompTransportMessageMeta | undefined,
-    principalMeta: ScompTransportMessageMeta | undefined,
-  ): ScompTransportMessageMeta | undefined {
-    if (!baseMeta && !principalMeta) {
-      return undefined;
-    }
-
-    return {
-      ...(baseMeta ?? {}),
-      ...(principalMeta ?? {}),
-    };
-  }
-
-  private async checkSecurity(
-    ctx: Omit<ScompTransportSecurityContext, "principal">,
-  ): Promise<{ allowed: boolean; principal?: ScompTransportPrincipal }> {
-    const policy = this.config.security;
-    if (!policy) {
-      return { allowed: true };
-    }
-
-    const principal = policy.authenticate
-      ? await policy.authenticate(ctx)
-      : undefined;
-
-    if (!policy.authorize) {
-      return { allowed: true, principal: principal ?? undefined };
-    }
-
-    const allowed = Boolean(
-      await policy.authorize({
-        ...ctx,
-        principal: principal ?? undefined,
-      }),
-    );
-
-    return { allowed, principal: principal ?? undefined };
   }
 }
 

--- a/packages/transport-websocket-client/tsconfig.json
+++ b/packages/transport-websocket-client/tsconfig.json
@@ -8,6 +8,7 @@
   },
   "references": [
     { "path": "../core" },
+    { "path": "../transport-shared" },
     { "path": "../types" }
   ],
   "include": ["src/**/*"]

--- a/packages/transport-websocket-server-node/package.json
+++ b/packages/transport-websocket-server-node/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@scomp/core": "workspace:*",
+    "@scomp/transport-shared": "workspace:*",
     "@scomp/types": "workspace:*",
     "@scomp/transport-websocket-client": "workspace:*",
     "@scomp/transport-websocket-server-runtime": "workspace:*",

--- a/packages/transport-websocket-server-node/src/index.ts
+++ b/packages/transport-websocket-server-node/src/index.ts
@@ -13,6 +13,7 @@ import type {
   ScompFeedChunkEnvelope,
   ScompTransportMessageMeta,
 } from "@scomp/types";
+import { toPrincipalMeta } from "@scomp/transport-shared";
 import {
   parseTransportMessage,
   StreamClosedError,
@@ -61,27 +62,6 @@ function toText(data: RawData): string {
   }
 
   return Buffer.from(data).toString("utf8");
-}
-
-function toPrincipalMeta(
-  principal: ScompTransportPrincipal | undefined,
-): ScompTransportMessageMeta | undefined {
-  if (!principal) {
-    return undefined;
-  }
-
-  return {
-    auth: {
-      subject: principal.subject,
-      tenantId: principal.tenantId,
-      scopes: principal.scopes,
-      claims: principal.claims,
-      issuedAt: principal.issuedAt,
-      expiresAt: principal.expiresAt,
-      authType: principal.authType,
-    },
-    tenantId: principal.tenantId,
-  };
 }
 
 export class WebSocketServerTransport implements ITransport {
@@ -143,7 +123,10 @@ export class WebSocketServerTransport implements ITransport {
       this.sockets.add(socketWithPrincipal);
 
       socket.on("message", async (data: RawData) => {
-        const body = parseTransportMessage(toText(data)) as TransportMessage;
+        const body = parseTransportMessage(toText(data));
+        if (!body) {
+          return;
+        }
         await this.runtime.handleIncoming(socketWithPrincipal, body);
       });
 

--- a/packages/transport-websocket-server-node/tsconfig.json
+++ b/packages/transport-websocket-server-node/tsconfig.json
@@ -8,6 +8,7 @@
   },
   "references": [
     { "path": "../core" },
+    { "path": "../transport-shared" },
     { "path": "../types" },
     { "path": "../transport-websocket-client" },
     { "path": "../transport-websocket-server-runtime" }

--- a/packages/transport-websocket-server-runtime/package.json
+++ b/packages/transport-websocket-server-runtime/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@scomp/core": "workspace:*",
+    "@scomp/transport-shared": "workspace:*",
     "@scomp/types": "workspace:*"
   }
 }

--- a/packages/transport-websocket-server-runtime/src/index.ts
+++ b/packages/transport-websocket-server-runtime/src/index.ts
@@ -1,134 +1,46 @@
 import {
   SCOMP_FRAMEWORK_PREFIX,
+  SCOMP_SCOPE,
   ScompFrameworkMethods,
   type CompiledRoute,
-  type ControlledAsyncIterable,
 } from "@scomp/core";
 import {
   createFeedHash,
   type ScompErrorCode,
   type ScompFeedChunkEnvelope,
   type ScompTransportMessageMeta,
-  type ScompTransportPrincipal,
-  type ScompTransportRequestEnvelope,
-  type ScompTransportResponseEnvelope,
   type ScompTransportSecurityContext,
-  type ScompTransportSecurityPolicy,
 } from "@scomp/types";
+import { toPrincipalMeta } from "@scomp/transport-shared";
+import {
+  StreamClosedError,
+  ensureFeedIterable,
+  isControlledAsyncIterable,
+  type CheckSecurityResult,
+  type RunningFeed,
+  type RuntimeSocket,
+  type TransportMessage,
+  type WebSocketServerRuntimeConfig,
+} from "./types";
 
-export class StreamClosedError extends Error {
-  constructor(streamHash: string) {
-    super(`Feed stream closed for hash: ${streamHash}`);
-    this.name = "StreamClosedError";
-  }
-}
+export { StreamClosedError, parseTransportMessage } from "./types";
+export type {
+  RuntimeSocket,
+  TransportMessage,
+  WebSocketServerRuntimeConfig,
+} from "./types";
 
-export interface RuntimeSocket {
-  readyState: number;
-  send(payload: string): void;
-}
-
-interface RunningFeed<Socket extends RuntimeSocket> {
-  key: string;
-  exchange: string;
-  subscribers: Set<Socket>;
-  abortController: AbortController;
-  controller?: Record<string, (payload: unknown) => unknown>;
-}
-
-export type TransportMessage = ScompTransportRequestEnvelope;
-
-type CheckSecurityResult = {
-  allowed: boolean;
-  principal?: ScompTransportPrincipal;
+type FeedChunkData = {
+  feed: string;
+  type: "next" | "done" | "error";
+  payload?: unknown;
+  message?: string;
 };
-
-type RuntimeHandlers<Socket extends RuntimeSocket> = {
-  invokeRoute: (
-    route: CompiledRoute,
-    message: TransportMessage,
-  ) => Promise<unknown>;
-  isSocketOpen: (socket: Socket) => boolean;
-  onReply: (socket: Socket, response: ScompTransportResponseEnvelope) => void;
-  onFeedChunk: (socket: Socket, chunk: ScompFeedChunkEnvelope) => void;
-  onFeedExchange: (hash: string) => string;
-  toPrincipalMeta?: (
-    principal: ScompTransportPrincipal | undefined,
-  ) => ScompTransportMessageMeta | undefined;
-};
-
-export type WebSocketServerRuntimeConfig<Socket extends RuntimeSocket> = {
-  security?: ScompTransportSecurityPolicy;
-  getSocketPrincipal: (socket: Socket) => ScompTransportPrincipal | undefined;
-  setSocketPrincipal: (
-    socket: Socket,
-    principal: ScompTransportPrincipal,
-  ) => void;
-} & RuntimeHandlers<Socket>;
-
-function safeJsonParse(text: string): any {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return {};
-  }
-}
-
-export function parseTransportMessage(text: string): TransportMessage {
-  return safeJsonParse(text) as TransportMessage;
-}
-
-function ensureFeedIterable(value: unknown): AsyncIterable<unknown> {
-  if (
-    value &&
-    typeof (value as AsyncIterable<unknown>)[Symbol.asyncIterator] ===
-      "function"
-  ) {
-    return value as AsyncIterable<unknown>;
-  }
-
-  throw new Error("Feed route handler did not return an AsyncIterable.");
-}
-
-function isControlledAsyncIterable(
-  value: unknown,
-): value is ControlledAsyncIterable<unknown, Record<string, Function>> {
-  return (
-    value != null &&
-    typeof (value as ControlledAsyncIterable<unknown>).controller ===
-      "object" &&
-    (value as ControlledAsyncIterable<unknown>).controller !== null
-  );
-}
-
-function defaultToPrincipalMeta(
-  principal: ScompTransportPrincipal | undefined,
-): ScompTransportMessageMeta | undefined {
-  if (!principal) {
-    return undefined;
-  }
-
-  return {
-    auth: {
-      subject: principal.subject,
-      tenantId: principal.tenantId,
-      scopes: principal.scopes,
-      claims: principal.claims,
-      issuedAt: principal.issuedAt,
-      expiresAt: principal.expiresAt,
-      authType: principal.authType,
-    },
-    tenantId: principal.tenantId,
-  };
-}
 
 export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
   private router?: Record<string, CompiledRoute>;
   private readonly runningFeeds = new Map<string, RunningFeed<Socket>>();
-  /**
-   * Shared controllers for fanout feeds, keyed by route+feedHash.
-   * Multiple RunningFeed entries may reference the same shared controller.
-   */
+  /** Shared controllers for fanout feeds, keyed by route+feedHash. */
   private readonly sharedControllers = new Map<
     string,
     Record<string, (payload: unknown) => unknown>
@@ -154,9 +66,7 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
       meta: body.meta,
     });
 
-    const meta = (this.config.toPrincipalMeta ?? defaultToPrincipalMeta)(
-      principal,
-    );
+    const meta = (this.config.toPrincipalMeta ?? toPrincipalMeta)(principal);
 
     if (!allowed) {
       this.replyWithError(
@@ -203,7 +113,7 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
       try {
         await this.config.invokeRoute(routeEntry, body);
       } catch {
-        // Signals are fire-and-forget and do not reply.
+        /* fire-and-forget */
       }
       return;
     }
@@ -218,10 +128,7 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
 
   detachSocketFromFeeds(socket: Socket): void {
     for (const runningFeed of this.runningFeeds.values()) {
-      if (!runningFeed.subscribers.has(socket)) {
-        continue;
-      }
-
+      if (!runningFeed.subscribers.has(socket)) continue;
       runningFeed.subscribers.delete(socket);
       if (runningFeed.subscribers.size === 0) {
         runningFeed.abortController.abort(
@@ -296,7 +203,7 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
       try {
         await controller[method](body.payload);
       } catch {
-        // Signals are fire-and-forget and do not reply.
+        /* fire-and-forget */
       }
       return;
     }
@@ -352,13 +259,10 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
         string,
         (payload: unknown) => unknown
       >;
-
-      if (result.__scope === "fanout") {
+      if (result[SCOMP_SCOPE] === "fanout") {
         const existing = this.sharedControllers.get(hash);
         runningFeed.controller = existing ?? controllerRef;
-        if (!existing) {
-          this.sharedControllers.set(hash, controllerRef);
-        }
+        if (!existing) this.sharedControllers.set(hash, controllerRef);
       } else {
         runningFeed.controller = controllerRef;
       }
@@ -378,14 +282,12 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
         if (runningFeed.abortController.signal.aborted) {
           throw runningFeed.abortController.signal.reason;
         }
-
         this.broadcastFeedChunk(runningFeed, {
           feed: runningFeed.key,
           type: "next",
           payload: chunk,
         });
       }
-
       this.broadcastFeedChunk(runningFeed, {
         feed: runningFeed.key,
         type: "done",
@@ -404,18 +306,10 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
 
   private broadcastFeedChunk(
     runningFeed: RunningFeed<Socket>,
-    chunk: {
-      feed: string;
-      type: "next" | "done" | "error";
-      payload?: unknown;
-      message?: string;
-    },
+    chunk: FeedChunkData,
   ): void {
     for (const socket of runningFeed.subscribers) {
-      if (!this.config.isSocketOpen(socket)) {
-        continue;
-      }
-
+      if (!this.config.isSocketOpen(socket)) continue;
       this.config.onFeedChunk(socket, {
         channel: "feed",
         ...chunk,
@@ -429,15 +323,12 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
     payload: unknown,
     meta?: ScompTransportMessageMeta,
   ): void {
-    if (!id || !this.config.isSocketOpen(socket)) {
-      return;
-    }
-
+    if (!id || !this.config.isSocketOpen(socket)) return;
     this.config.onReply(socket, {
       id,
       payload,
       meta,
-    } satisfies ScompTransportResponseEnvelope);
+    } satisfies import("@scomp/types").ScompTransportResponseEnvelope);
   }
 
   private replyWithError(
@@ -447,16 +338,13 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
     meta?: ScompTransportMessageMeta,
     code?: ScompErrorCode,
   ): void {
-    if (!id || !this.config.isSocketOpen(socket)) {
-      return;
-    }
-
+    if (!id || !this.config.isSocketOpen(socket)) return;
     this.config.onReply(socket, {
       id,
       error: error instanceof Error ? error.message : String(error),
       code,
       meta,
-    } satisfies ScompTransportResponseEnvelope);
+    } satisfies import("@scomp/types").ScompTransportResponseEnvelope);
   }
 
   private async checkSecurity(
@@ -475,22 +363,15 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
     const principal = policy.authenticate
       ? await policy.authenticate(ctx)
       : rememberedPrincipal;
-
-    if (principal) {
-      this.config.setSocketPrincipal(socket, principal);
-    }
+    if (principal) this.config.setSocketPrincipal(socket, principal);
 
     if (!policy.authorize) {
       return { allowed: true, principal: principal ?? undefined };
     }
 
     const allowed = Boolean(
-      await policy.authorize({
-        ...ctx,
-        principal: principal ?? undefined,
-      }),
+      await policy.authorize({ ...ctx, principal: principal ?? undefined }),
     );
-
     return { allowed, principal: principal ?? undefined };
   }
 }

--- a/packages/transport-websocket-server-runtime/src/types.ts
+++ b/packages/transport-websocket-server-runtime/src/types.ts
@@ -1,0 +1,93 @@
+import type { CompiledRoute, ControlledAsyncIterable } from "@scomp/core";
+import type {
+  ScompFeedChunkEnvelope,
+  ScompTransportMessageMeta,
+  ScompTransportPrincipal,
+  ScompTransportRequestEnvelope,
+  ScompTransportResponseEnvelope,
+  ScompTransportSecurityPolicy,
+} from "@scomp/types";
+import { safeJsonParse } from "@scomp/transport-shared";
+
+export class StreamClosedError extends Error {
+  constructor(streamHash: string) {
+    super(`Feed stream closed for hash: ${streamHash}`);
+    this.name = "StreamClosedError";
+  }
+}
+
+export interface RuntimeSocket {
+  readyState: number;
+  send(payload: string): void;
+}
+
+export interface RunningFeed<Socket extends RuntimeSocket> {
+  key: string;
+  exchange: string;
+  subscribers: Set<Socket>;
+  abortController: AbortController;
+  controller?: Record<string, (payload: unknown) => unknown>;
+}
+
+export type TransportMessage = ScompTransportRequestEnvelope;
+
+export type CheckSecurityResult = {
+  allowed: boolean;
+  principal?: ScompTransportPrincipal;
+};
+
+export type RuntimeHandlers<Socket extends RuntimeSocket> = {
+  invokeRoute: (
+    route: CompiledRoute,
+    message: TransportMessage,
+  ) => Promise<unknown>;
+  isSocketOpen: (socket: Socket) => boolean;
+  onReply: (socket: Socket, response: ScompTransportResponseEnvelope) => void;
+  onFeedChunk: (socket: Socket, chunk: ScompFeedChunkEnvelope) => void;
+  onFeedExchange: (hash: string) => string;
+  toPrincipalMeta?: (
+    principal: ScompTransportPrincipal | undefined,
+  ) => ScompTransportMessageMeta | undefined;
+};
+
+export type WebSocketServerRuntimeConfig<Socket extends RuntimeSocket> = {
+  security?: ScompTransportSecurityPolicy;
+  getSocketPrincipal: (socket: Socket) => ScompTransportPrincipal | undefined;
+  setSocketPrincipal: (
+    socket: Socket,
+    principal: ScompTransportPrincipal,
+  ) => void;
+} & RuntimeHandlers<Socket>;
+
+export function parseTransportMessage(
+  text: string,
+): TransportMessage | undefined {
+  const parsed = safeJsonParse(text);
+  if (!parsed.ok) {
+    return undefined;
+  }
+  return parsed.value as TransportMessage;
+}
+
+export function ensureFeedIterable(value: unknown): AsyncIterable<unknown> {
+  if (
+    value &&
+    typeof (value as AsyncIterable<unknown>)[Symbol.asyncIterator] ===
+      "function"
+  ) {
+    return value as AsyncIterable<unknown>;
+  }
+
+  throw new Error("Feed route handler did not return an AsyncIterable.");
+}
+
+export function isControlledAsyncIterable(
+  value: unknown,
+): value is ControlledAsyncIterable<unknown, Record<string, Function>> {
+  return (
+    value != null &&
+    typeof (value as ControlledAsyncIterable<unknown>).controller ===
+      "object" &&
+    (value as ControlledAsyncIterable<unknown>).controller !== null
+  );
+}

--- a/packages/transport-websocket-server-runtime/tsconfig.json
+++ b/packages/transport-websocket-server-runtime/tsconfig.json
@@ -8,6 +8,7 @@
   },
   "references": [
     { "path": "../core" },
+    { "path": "../transport-shared" },
     { "path": "../types" }
   ],
   "include": ["src/**/*"]

--- a/packages/transport-websocket-server/package.json
+++ b/packages/transport-websocket-server/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@scomp/core": "workspace:*",
+    "@scomp/transport-shared": "workspace:*",
     "@scomp/transport-websocket-browser": "workspace:*",
     "@scomp/types": "workspace:*",
     "@scomp/transport-websocket-client": "workspace:*",

--- a/packages/transport-websocket-server/src/index.ts
+++ b/packages/transport-websocket-server/src/index.ts
@@ -9,6 +9,7 @@ import {
   type ScompTransportMessageMeta,
   type ScompTransportResponseEnvelope,
 } from "@scomp/types";
+import { toPrincipalMeta } from "@scomp/transport-shared";
 import {
   parseTransportMessage,
   StreamClosedError,
@@ -92,27 +93,6 @@ function toText(data: string | Buffer | ArrayBuffer | Uint8Array): string {
   return Buffer.from(data).toString("utf8");
 }
 
-function toPrincipalMeta(
-  principal: ScompTransportPrincipal | undefined,
-): ScompTransportMessageMeta | undefined {
-  if (!principal) {
-    return undefined;
-  }
-
-  return {
-    auth: {
-      subject: principal.subject,
-      tenantId: principal.tenantId,
-      scopes: principal.scopes,
-      claims: principal.claims,
-      issuedAt: principal.issuedAt,
-      expiresAt: principal.expiresAt,
-      authType: principal.authType,
-    },
-    tenantId: principal.tenantId,
-  };
-}
-
 function ensureSocketState(socket: BunLikeServerWebSocket): BunSocketWithState {
   const withState = socket as BunSocketWithState;
   withState.data = withState.data ?? {};
@@ -194,6 +174,9 @@ export class WebSocketServerTransport implements ITransport {
         message: (socket: BunLikeServerWebSocket, data) => {
           const socketWithState = ensureSocketState(socket);
           const body = parseTransportMessage(toText(data));
+          if (!body) {
+            return;
+          }
           void this.runtime.handleIncoming(socketWithState, body);
         },
         close: (socket: BunLikeServerWebSocket) => {

--- a/packages/transport-websocket-server/tsconfig.json
+++ b/packages/transport-websocket-server/tsconfig.json
@@ -8,6 +8,7 @@
   },
   "references": [
     { "path": "../core" },
+    { "path": "../transport-shared" },
     { "path": "../types" },
     { "path": "../transport-websocket-browser" },
     { "path": "../transport-websocket-client" },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,6 +4,7 @@
     { "path": "./packages/types" },
     { "path": "./packages/core" },
     { "path": "./packages/client" },
+    { "path": "./packages/transport-shared" },
     { "path": "./packages/transport-rabbitmq" },
     { "path": "./packages/transport-browser-windows" },
     { "path": "./packages/transport-inprocess" },


### PR DESCRIPTION
﻿## Summary

Resolves all 5 tech debt issues discovered during the code quality audit of the Core v2 and Controlled Feeds epics.

### Changes

- **New package @scomp/transport-shared** — centralizes 6 utility functions (`safeJsonParse`, `checkSecurity`, `toPriorityMeta`, `toPrincipalMeta`, `mergeMeta`, `isFeedChunkEnvelope`) previously copy-pasted across 7 transport packages (scomp-dbp)
- **safeJsonParse returns JsonParseResult discriminated union** instead of ny — all 5 callers updated for type-safe error handling (scomp-66m)
- **__scope replaced with Symbol.for("scomp.scope")** on ControlledAsyncIterable — prevents property collisions and enables cross-realm safety (scomp-6f5)
- **generateNodeId adds random suffix** — prevents node ID collisions when multiple peers start in the same millisecond (scomp-7ms)
- **	ransport-rabbitmq split from 994-line monolith into 5 focused modules** — connection, RPC, feed, client, types (scomp-zm4)
- **Type extractions** in ws-browser and ws-server-runtime for cohesive file responsibility

### Issues resolved

- scomp-dbp: Transport DRY debt — shared utilities package
- scomp-66m: safeJsonParse type safety
- scomp-6f5: Symbol-based scope metadata
- scomp-7ms: Node ID collision prevention
- scomp-zm4: File size violations — RabbitMQ split

### Verification

- `bunx turbo run build` — 14/14 packages pass
- `bunx turbo run test` — 23/23 tasks pass, 170+ tests
- Working tree clean
