### PR TITLE
fix: publish built package artifacts

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/client"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/core"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/transport-browser-windows/package.json
+++ b/packages/transport-browser-windows/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/transport-browser-windows"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/transport-inprocess/package.json
+++ b/packages/transport-inprocess/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/transport-inprocess"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/transport-rabbitmq/package.json
+++ b/packages/transport-rabbitmq/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/transport-rabbitmq"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/transport-shared/package.json
+++ b/packages/transport-shared/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/transport-shared"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/transport-websocket-client/package.json
+++ b/packages/transport-websocket-client/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/transport-websocket-client"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/transport-websocket-server-runtime/package.json
+++ b/packages/transport-websocket-server-runtime/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/transport-websocket-server-runtime"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/transport-websocket-server/package.json
+++ b/packages/transport-websocket-server/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/transport-websocket-server"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/transport-websocket-shared/package.json
+++ b/packages/transport-websocket-shared/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/transport-websocket-shared"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/surikaterna/scomp.git",
+    "url": "git+https://github.com/surikaterna/scomp.git",
     "directory": "packages/types"
   },
   "keywords": [
@@ -18,6 +18,9 @@
     "node": ">=18"
   },
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Adds npm files allowlists so public @scompr packages publish built dist artifacts instead of src/test payloads.
- Normalizes repository URLs to npm's expected git+https form.
- Keeps @scompr/demo private/unpublished.

## Validation
- scomp-s3b Auditor verified: bun run build, npm publish --dry-run --access public --workspaces --include-workspace-root=false --tag next, bun run lint, bun run test.
- Dry-run included dist artifacts and skipped private demo.

Issue: scomp-s3b