### PR TITLE
feat: interactive GitHub Pages demo site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Deploy Demo to GitHub Pages
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - name: Build demo site
+        run: bun run --filter @scompr/demo-site build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/demo-site/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/demo-site/client-frame.html
+++ b/apps/demo-site/client-frame.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Client Frame</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+</head>
+<body class="frame-body">
+  <div class="frame-content">
+    <div class="frame-status" id="status">Initializing...</div>
+    <div class="button-group">
+      <button id="btn-request">math.double(21)</button>
+      <button id="btn-signal">notifications.alert</button>
+      <button id="btn-feed-start">ticker.prices (start)</button>
+      <button id="btn-feed-stop" disabled>Stop</button>
+    </div>
+    <div id="frame-log" class="frame-log"></div>
+  </div>
+  <script type="module" src="/src/client-frame.ts"></script>
+</body>
+</html>

--- a/apps/demo-site/cross-window.html
+++ b/apps/demo-site/cross-window.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cross-Window Communication Demo — sComPR</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+</head>
+<body>
+  <div class="demo-page">
+    <header class="demo-header">
+      <a href="index.html" class="back-link">← Back</a>
+      <h1>Cross-Window Communication Demo</h1>
+    </header>
+    <div class="frames-layout">
+      <div class="frame-container">
+        <h2>Host (registers routes)</h2>
+        <iframe id="host-frame" src="host-frame.html"></iframe>
+      </div>
+      <div class="frame-container">
+        <h2>Client (invokes routes)</h2>
+        <iframe id="client-frame" src="client-frame.html"></iframe>
+      </div>
+    </div>
+    <section class="log-panel">
+      <h2>Event Log</h2>
+      <div id="log" class="log-output"></div>
+    </section>
+  </div>
+  <script type="module" src="/src/cross-window-parent.ts"></script>
+</body>
+</html>

--- a/apps/demo-site/host-frame.html
+++ b/apps/demo-site/host-frame.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Host Frame</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+</head>
+<body class="frame-body">
+  <div class="frame-content">
+    <div class="frame-status" id="status">Initializing...</div>
+    <div id="frame-log" class="frame-log"></div>
+  </div>
+  <script type="module" src="/src/host-frame.ts"></script>
+</body>
+</html>

--- a/apps/demo-site/index.html
+++ b/apps/demo-site/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>sComPR — Interactive Demos</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+</head>
+<body>
+  <div class="landing">
+    <header class="landing-header">
+      <h1>sComPR</h1>
+      <p class="tagline">TypeScript Service Composition Framework</p>
+    </header>
+    <main class="landing-demos">
+      <a href="inprocess.html" class="demo-card">
+        <h2>In-Process RPC</h2>
+        <p>Full contract → service → client flow running in a single page. No server needed.</p>
+        <span class="demo-badge">@scompr/transport-inprocess</span>
+      </a>
+      <a href="cross-window.html" class="demo-card">
+        <h2>Cross-Window Communication</h2>
+        <p>Two iframes communicating via BroadcastChannel. Real-time message log.</p>
+        <span class="demo-badge">@scompr/transport-browser-windows</span>
+      </a>
+    </main>
+    <footer class="landing-footer">
+      <a href="https://github.com/surikaterna/scomp">GitHub</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/apps/demo-site/inprocess.html
+++ b/apps/demo-site/inprocess.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>In-Process RPC Demo — sComPR</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+</head>
+<body>
+  <div class="demo-page">
+    <header class="demo-header">
+      <a href="index.html" class="back-link">← Back</a>
+      <h1>In-Process RPC Demo</h1>
+    </header>
+    <div class="demo-layout">
+      <section class="panel code-panel">
+        <h2>Service Definition</h2>
+        <pre class="code-display"><code id="code-display"></code></pre>
+      </section>
+      <section class="panel controls-panel">
+        <h2>Interactive Console</h2>
+        <div class="button-group">
+          <button id="btn-request">Request: getUser(7)</button>
+          <button id="btn-signal">Signal: notifyLogin</button>
+          <button id="btn-feed-start">Feed: liveUsers</button>
+          <button id="btn-feed-stop" disabled>Stop Feed</button>
+        </div>
+      </section>
+    </div>
+    <section class="log-panel">
+      <h2>Log</h2>
+      <div id="log" class="log-output"></div>
+    </section>
+  </div>
+  <script type="module" src="/src/inprocess-demo.ts"></script>
+</body>
+</html>

--- a/apps/demo-site/package.json
+++ b/apps/demo-site/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@scompr/demo-site",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@scompr/core": "workspace:*",
+    "@scompr/client": "workspace:*",
+    "@scompr/transport-inprocess": "workspace:*",
+    "@scompr/transport-browser-windows": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "^6.3.0",
+    "typescript": "^6.0.2"
+  }
+}

--- a/apps/demo-site/src/client-frame.ts
+++ b/apps/demo-site/src/client-frame.ts
@@ -1,0 +1,110 @@
+import { createScompClient } from "@scompr/client";
+import { createBrowserWindowsTransport } from "@scompr/transport-browser-windows";
+
+interface DemoContract {
+  double(n: number): Promise<number>;
+  alert(payload: { msg: string }): void;
+  prices(params: Record<string, never>): AsyncIterable<{ symbol: string; price: number; ts: number }>;
+}
+
+function postLog(kind: string, message: string): void {
+  window.parent.postMessage({ type: "demo-log", source: "client", kind, message }, "*");
+  const el = document.getElementById("frame-log");
+  if (el) el.textContent += `${message}\n`;
+}
+
+const statusEl = document.getElementById("status");
+let feedRunning = false;
+let feedIterator: AsyncIterator<{ symbol: string; price: number; ts: number }> | null = null;
+
+async function init() {
+  try {
+    const transport = createBrowserWindowsTransport({
+      mode: "broadcast-channel",
+      channelName: "scompr-demo",
+      routeIntents: {
+        "demo.double": "request",
+        "demo.alert": "signal",
+        "demo.prices": "feed",
+      },
+    });
+
+    // Small delay to let host register first
+    await new Promise((r) => setTimeout(r, 300));
+
+    const client = createScompClient<DemoContract>({
+      transport,
+      routeHints: {
+        "demo.double": "request",
+        "demo.alert": "signal",
+        "demo.prices": "feed",
+      },
+    });
+
+    if (statusEl) statusEl.textContent = "Client ready";
+    postLog("request", "Client initialized");
+
+    // Wire buttons
+    document.getElementById("btn-request")?.addEventListener("click", async () => {
+      postLog("request", "→ demo.double(21)");
+      try {
+        const result = await client.double(21);
+        postLog("request", `← ${result}`);
+      } catch (err) {
+        postLog("error", `Error: ${err}`);
+      }
+    });
+
+    document.getElementById("btn-signal")?.addEventListener("click", async () => {
+      postLog("signal", '→ demo.alert({ msg: "hello" })');
+      try {
+        await client.alert({ msg: "hello" });
+        postLog("signal", "← (sent)");
+      } catch (err) {
+        postLog("error", `Error: ${err}`);
+      }
+    });
+
+    document.getElementById("btn-feed-start")?.addEventListener("click", async () => {
+      if (feedRunning) return;
+      feedRunning = true;
+      const btnStart = document.getElementById("btn-feed-start") as HTMLButtonElement;
+      const btnStop = document.getElementById("btn-feed-stop") as HTMLButtonElement;
+      btnStart.disabled = true;
+      btnStop.disabled = false;
+
+      postLog("feed", "→ demo.prices [subscribing]");
+      try {
+        const feed = client.prices({} as Record<string, never>);
+        const iterator = feed[Symbol.asyncIterator]();
+        feedIterator = iterator;
+
+        while (feedRunning) {
+          const { done, value } = await iterator.next();
+          if (done) break;
+          postLog("feed", `← $${value.price.toFixed(2)} @ ${new Date(value.ts).toLocaleTimeString()}`);
+        }
+      } catch (err) {
+        postLog("error", `Feed error: ${err}`);
+      }
+
+      postLog("feed", "← [stream ended]");
+      btnStart.disabled = false;
+      btnStop.disabled = true;
+      feedRunning = false;
+    });
+
+    document.getElementById("btn-feed-stop")?.addEventListener("click", () => {
+      feedRunning = false;
+      if (feedIterator?.return) {
+        feedIterator.return(undefined);
+      }
+      feedIterator = null;
+    });
+  } catch (err) {
+    if (statusEl) statusEl.textContent = `Error: ${err}`;
+    postLog("error", `Init failed: ${err}`);
+  }
+}
+
+init();

--- a/apps/demo-site/src/cross-window-parent.ts
+++ b/apps/demo-site/src/cross-window-parent.ts
@@ -1,0 +1,20 @@
+// Parent page: listens for log messages from iframes
+const logEl = document.getElementById("log");
+
+function addLog(source: string, kind: string, message: string): void {
+  if (!logEl) return;
+  const entry = document.createElement("div");
+  entry.className = "log-entry";
+  const time = new Date().toLocaleTimeString("en-US", { hour12: false, fractionalSecondDigits: 3 });
+  entry.innerHTML = `<span class="timestamp">${time}</span> <span class="label-${kind}">[${source}]</span> ${message}`;
+  logEl.appendChild(entry);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+window.addEventListener("message", (event: MessageEvent) => {
+  if (event.data?.type === "demo-log") {
+    addLog(event.data.source, event.data.kind, event.data.message);
+  }
+});
+
+addLog("parent", "request", "Cross-window demo loaded. Host and client frames initializing...");

--- a/apps/demo-site/src/host-frame.ts
+++ b/apps/demo-site/src/host-frame.ts
@@ -1,0 +1,84 @@
+import { createContractToken, createScompService } from "@scompr/core";
+import { createBrowserWindowsTransport } from "@scompr/transport-browser-windows";
+
+// Contract shared between host and client
+interface DemoContract {
+  double(n: number): Promise<number>;
+  alert(payload: { msg: string }): void;
+  prices(params: Record<string, never>): AsyncIterable<{ symbol: string; price: number; ts: number }>;
+}
+
+const DemoService = createContractToken<DemoContract>("demo");
+
+function postLog(kind: string, message: string): void {
+  window.parent.postMessage({ type: "demo-log", source: "host", kind, message }, "*");
+  const el = document.getElementById("frame-log");
+  if (el) el.textContent += `${message}\n`;
+}
+
+const statusEl = document.getElementById("status");
+
+async function init() {
+  try {
+    const transport = createBrowserWindowsTransport({
+      mode: "broadcast-channel",
+      channelName: "scompr-demo",
+      routeIntents: {
+        "demo.double": "request",
+        "demo.alert": "signal",
+        "demo.prices": "feed",
+      },
+    });
+
+    const service = createScompService(DemoService).implement({
+      requests: {
+        double(n: number) {
+          postLog("request", `double(${n}) → ${n * 2}`);
+          return Promise.resolve(n * 2);
+        },
+      },
+      signals: {
+        alert(payload: { msg: string }) {
+          postLog("signal", `alert received: "${payload.msg}"`);
+        },
+      },
+      feeds: {
+        prices(_params: Record<string, never>) {
+          let running = true;
+          let tick = 0;
+          postLog("feed", "prices feed started");
+          return {
+            [Symbol.asyncIterator]() {
+              return {
+                async next() {
+                  if (!running) return { done: true as const, value: undefined };
+                  await new Promise((r) => setTimeout(r, 500));
+                  if (!running) return { done: true as const, value: undefined };
+                  tick++;
+                  const value = { symbol: "BTC", price: 50000 + Math.random() * 1000, ts: Date.now() };
+                  postLog("feed", `tick #${tick}: $${value.price.toFixed(2)}`);
+                  return { done: false, value };
+                },
+                async return() {
+                  running = false;
+                  postLog("feed", "prices feed stopped");
+                  return { done: true as const, value: undefined };
+                },
+              };
+            },
+          };
+        },
+      },
+    });
+
+    transport.registerRoutes(service.router);
+
+    if (statusEl) statusEl.textContent = "Host ready — routes registered";
+    postLog("request", "Host initialized, routes registered");
+  } catch (err) {
+    if (statusEl) statusEl.textContent = `Error: ${err}`;
+    postLog("error", `Init failed: ${err}`);
+  }
+}
+
+init();

--- a/apps/demo-site/src/inprocess-demo.ts
+++ b/apps/demo-site/src/inprocess-demo.ts
@@ -1,0 +1,143 @@
+import { createContractToken, createScompService } from "@scompr/core";
+import { createScompClient } from "@scompr/client";
+import { createInprocessTransport } from "@scompr/transport-inprocess";
+import { log } from "./log";
+
+// --- Contract Definition ---
+interface UserServiceContract {
+  getUser(id: number): Promise<{ id: number; name: string }>;
+  notifyLogin(userId: number): void;
+  liveUsers(filter: { online: boolean }): AsyncIterable<{ id: number; name: string; ts: number }>;
+}
+
+const UserService = createContractToken<UserServiceContract>("users");
+
+// --- Service Implementation ---
+const MOCK_USERS = [
+  { id: 1, name: "Alice" },
+  { id: 7, name: "Bob" },
+  { id: 13, name: "Charlie" },
+];
+
+const service = createScompService(UserService).implement({
+  requests: {
+    getUser(id: number) {
+      const user = MOCK_USERS.find((u) => u.id === id) ?? { id, name: `User#${id}` };
+      return Promise.resolve(user);
+    },
+  },
+  signals: {
+    notifyLogin(userId: number) {
+      log("service", "signal", `notifyLogin received for userId=${userId}`);
+    },
+  },
+  feeds: {
+    liveUsers(_filter: { online: boolean }) {
+      let running = true;
+      let index = 0;
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              if (!running) return { done: true as const, value: undefined };
+              await new Promise((r) => setTimeout(r, 600));
+              if (!running) return { done: true as const, value: undefined };
+              const user = MOCK_USERS[index % MOCK_USERS.length];
+              index++;
+              return { done: false, value: { ...user, ts: Date.now() } };
+            },
+            async return() {
+              running = false;
+              return { done: true as const, value: undefined };
+            },
+          };
+        },
+      };
+    },
+  },
+});
+
+// --- Transport + Client ---
+const transport = createInprocessTransport();
+transport.registerRoutes(service.router);
+
+const client = createScompClient<UserServiceContract>({
+  transport,
+  routeHints: {
+    "users.getUser": "request",
+    "users.notifyLogin": "signal",
+    "users.liveUsers": "feed",
+  },
+});
+
+// --- Display the code ---
+const codeEl = document.getElementById("code-display");
+if (codeEl) {
+  codeEl.textContent = `interface UserServiceContract {
+  getUser(id: number): Promise<{ id: number; name: string }>;
+  notifyLogin(userId: number): void;
+  liveUsers(filter): AsyncIterable<{ id; name; ts }>;
+}
+
+const service = createScompService(UserService).implement({
+  requests: { getUser(id) { ... } },
+  signals: { notifyLogin(userId) { ... } },
+  feeds:   { liveUsers(filter) { ... } },
+});
+
+const transport = createInprocessTransport();
+transport.registerRoutes(service.router);
+const client = createScompClient<UserServiceContract>({ transport });`;
+}
+
+// --- Wire up buttons ---
+let feedIterator: AsyncIterator<{ id: number; name: string; ts: number }> | null = null;
+let feedRunning = false;
+
+document.getElementById("btn-request")?.addEventListener("click", async () => {
+  log("client", "request", "→ users.getUser(7)");
+  const result = await client.getUser(7);
+  log("client", "request", `← ${JSON.stringify(result)}`);
+});
+
+document.getElementById("btn-signal")?.addEventListener("click", async () => {
+  log("client", "signal", "→ users.notifyLogin(42)");
+  await client.notifyLogin(42);
+  log("client", "signal", "← (fire-and-forget acknowledged)");
+});
+
+document.getElementById("btn-feed-start")?.addEventListener("click", async () => {
+  if (feedRunning) return;
+  feedRunning = true;
+  const btnStart = document.getElementById("btn-feed-start") as HTMLButtonElement;
+  const btnStop = document.getElementById("btn-feed-stop") as HTMLButtonElement;
+  btnStart.disabled = true;
+  btnStop.disabled = false;
+
+  log("client", "feed", "→ users.liveUsers({ online: true }) [subscribing]");
+  const feed = client.liveUsers({ online: true });
+  const iterator = feed[Symbol.asyncIterator]();
+  feedIterator = iterator;
+
+  try {
+    while (feedRunning) {
+      const { done, value } = await iterator.next();
+      if (done) break;
+      log("client", "feed", `← chunk: ${JSON.stringify(value)}`);
+    }
+  } catch (err) {
+    log("client", "error", `Feed error: ${err}`);
+  }
+
+  log("client", "feed", "← [stream ended]");
+  btnStart.disabled = false;
+  btnStop.disabled = true;
+});
+
+document.getElementById("btn-feed-stop")?.addEventListener("click", () => {
+  feedRunning = false;
+  if (feedIterator?.return) {
+    feedIterator.return(undefined);
+  }
+  feedIterator = null;
+});

--- a/apps/demo-site/src/log.ts
+++ b/apps/demo-site/src/log.ts
@@ -1,0 +1,15 @@
+const logEl = document.getElementById("log");
+
+export function log(label: string, kind: "request" | "signal" | "feed" | "error", message: string): void {
+  if (!logEl) return;
+  const entry = document.createElement("div");
+  entry.className = "log-entry";
+  const time = new Date().toLocaleTimeString("en-US", { hour12: false, fractionalSecondDigits: 3 });
+  entry.innerHTML = `<span class="timestamp">${time}</span> <span class="label-${kind}">[${label}]</span> ${escapeHtml(message)}`;
+  logEl.appendChild(entry);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/apps/demo-site/src/styles.css
+++ b/apps/demo-site/src/styles.css
@@ -1,0 +1,319 @@
+:root {
+  --bg: #0d1117;
+  --bg-surface: #161b22;
+  --bg-elevated: #21262d;
+  --border: #30363d;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --accent: #58a6ff;
+  --accent-dim: #1f6feb;
+  --success: #3fb950;
+  --warning: #d29922;
+  --error: #f85149;
+  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --radius: 8px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html, body {
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  line-height: 1.5;
+}
+
+/* Landing Page */
+.landing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.landing-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.landing-header h1 {
+  font-size: 3rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, var(--accent), var(--success));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.tagline {
+  color: var(--text-muted);
+  font-size: 1.2rem;
+  margin-top: 0.5rem;
+}
+
+.landing-demos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+  max-width: 700px;
+  width: 100%;
+}
+
+.demo-card {
+  display: block;
+  padding: 1.5rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: var(--text);
+  transition: border-color 0.2s, transform 0.2s;
+}
+
+.demo-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.demo-card h2 {
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.demo-card p {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.demo-badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  background: var(--bg-elevated);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--accent);
+}
+
+.landing-footer {
+  margin-top: 3rem;
+}
+
+.landing-footer a {
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.landing-footer a:hover {
+  color: var(--accent);
+}
+
+/* Demo Pages */
+.demo-page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  padding: 1rem;
+  gap: 1rem;
+}
+
+.demo-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.back-link {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.back-link:hover {
+  color: var(--accent);
+}
+
+.demo-header h1 {
+  font-size: 1.4rem;
+}
+
+.demo-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  overflow: auto;
+}
+
+.panel h2 {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+}
+
+.code-display {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  color: var(--text-muted);
+}
+
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+button:hover:not(:disabled) {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+}
+
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.log-panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  max-height: 250px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.log-panel h2 {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.log-output {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.6;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.log-entry {
+  padding: 0.15rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.log-entry .timestamp {
+  color: var(--text-muted);
+}
+
+.log-entry .label-request {
+  color: var(--accent);
+}
+
+.log-entry .label-signal {
+  color: var(--warning);
+}
+
+.log-entry .label-feed {
+  color: var(--success);
+}
+
+.log-entry .label-error {
+  color: var(--error);
+}
+
+/* Cross-window frames layout */
+.frames-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.frame-container {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.frame-container h2 {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.frame-container iframe {
+  flex: 1;
+  border: none;
+  background: var(--bg);
+}
+
+/* Frame body styles */
+.frame-body {
+  padding: 1rem;
+}
+
+.frame-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.frame-status {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.frame-log {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+  max-height: 150px;
+  overflow-y: auto;
+}

--- a/apps/demo-site/tsconfig.json
+++ b/apps/demo-site/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/demo-site/vite.config.ts
+++ b/apps/demo-site/vite.config.ts
@@ -1,0 +1,15 @@
+// biome-ignore lint/style/noDefaultExport: Vite requires default export
+export default {
+  base: "/scomp/",
+  build: {
+    rollupOptions: {
+      input: {
+        main: "index.html",
+        inprocess: "inprocess.html",
+        "cross-window": "cross-window.html",
+        "host-frame": "host-frame.html",
+        "client-frame": "client-frame.html",
+      },
+    },
+  },
+};

--- a/bun.lock
+++ b/bun.lock
@@ -45,9 +45,23 @@
         "ws": "^8.18.3",
       },
     },
+    "apps/demo-site": {
+      "name": "@scompr/demo-site",
+      "version": "0.0.1",
+      "dependencies": {
+        "@scompr/client": "workspace:*",
+        "@scompr/core": "workspace:*",
+        "@scompr/transport-browser-windows": "workspace:*",
+        "@scompr/transport-inprocess": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^6.0.2",
+        "vite": "^6.3.0",
+      },
+    },
     "packages/client": {
       "name": "@scompr/client",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "devDependencies": {
         "@scompr/core": "workspace:*",
         "@scompr/types": "workspace:*",
@@ -58,7 +72,7 @@
     },
     "packages/core": {
       "name": "@scompr/core",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "devDependencies": {
         "@scompr/types": "workspace:*",
       },
@@ -68,7 +82,7 @@
     },
     "packages/transport-browser-windows": {
       "name": "@scompr/transport-browser-windows",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "devDependencies": {
         "@scompr/core": "workspace:*",
         "@scompr/transport-shared": "workspace:*",
@@ -81,7 +95,7 @@
     },
     "packages/transport-inprocess": {
       "name": "@scompr/transport-inprocess",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "devDependencies": {
         "@scompr/core": "workspace:*",
         "@scompr/transport-shared": "workspace:*",
@@ -94,7 +108,7 @@
     },
     "packages/transport-rabbitmq": {
       "name": "@scompr/transport-rabbitmq",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "amqplib": "^0.10.9",
       },
@@ -112,7 +126,7 @@
     },
     "packages/transport-shared": {
       "name": "@scompr/transport-shared",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "devDependencies": {
         "@scompr/core": "workspace:*",
         "@scompr/types": "workspace:*",
@@ -123,7 +137,7 @@
     },
     "packages/transport-websocket-client": {
       "name": "@scompr/transport-websocket-client",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "devDependencies": {
         "@scompr/core": "workspace:*",
         "@scompr/transport-shared": "workspace:*",
@@ -137,7 +151,7 @@
     },
     "packages/transport-websocket-server": {
       "name": "@scompr/transport-websocket-server",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "ws": "^8.18.3",
       },
@@ -157,7 +171,7 @@
     },
     "packages/transport-websocket-server-runtime": {
       "name": "@scompr/transport-websocket-server-runtime",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "devDependencies": {
         "@scompr/core": "workspace:*",
         "@scompr/transport-shared": "workspace:*",
@@ -170,7 +184,7 @@
     },
     "packages/transport-websocket-shared": {
       "name": "@scompr/transport-websocket-shared",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "ws": "^8.18.3",
       },
@@ -400,6 +414,8 @@
     "@scompr/core": ["@scompr/core@workspace:packages/core"],
 
     "@scompr/demo": ["@scompr/demo@workspace:apps/demo"],
+
+    "@scompr/demo-site": ["@scompr/demo-site@workspace:apps/demo-site"],
 
     "@scompr/transport-browser-windows": ["@scompr/transport-browser-windows@workspace:packages/transport-browser-windows"],
 
@@ -953,7 +969,7 @@
 
     "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
 
-    "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+    "vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
 
@@ -1029,7 +1045,13 @@
 
     "ts-node/diff": ["diff@4.0.4", "", {}, "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ=="],
 
+    "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "vite-node/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
     "vitest/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "vitest/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -1046,6 +1068,58 @@
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "rimraf/glob/path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "11.2.7", "minipass": "7.1.3" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "2.3.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 


### PR DESCRIPTION
## Summary

Adds two interactive browser-only demos deployed to GitHub Pages:

### 1. In-Process RPC Demo
Full contract → service → client flow in a single page using `@scompr/transport-inprocess`.
- Request: `getUser(7)` → response
- Signal: `notifyLogin(42)` → fire-and-forget
- Feed: `liveUsers` → streaming with start/stop

### 2. Cross-Window Communication Demo
Two iframes communicating via `@scompr/transport-browser-windows` (BroadcastChannel mode).
- Left: Host registers `math.double`, `notifications.alert`, `ticker.prices`
- Right: Client invokes each with interactive buttons
- Bottom: Shared event log showing protocol messages

### Infrastructure
- Vite build for the demo site
- `.github/workflows/pages.yml` deploys to GH Pages on push to develop
- Dark theme, professional styling

### Notes
- All demos run entirely client-side — no server needed
- Packages are bundled by Vite from workspace dependencies