### PR TITLE
feat(types): add v:1 protocol version field to wire envelopes

### DIFF
--- a/.changeset/protocol-version.md
+++ b/.changeset/protocol-version.md
@@ -1,0 +1,9 @@
+---
+"@scompr/types": patch
+"@scompr/transport-websocket-client": patch
+"@scompr/transport-websocket-server": patch
+"@scompr/transport-websocket-server-runtime": patch
+"@scompr/transport-rabbitmq": patch
+---
+
+Add `v: 1` protocol version field to all wire envelope types for forward compatibility

--- a/packages/transport-rabbitmq/src/index.ts
+++ b/packages/transport-rabbitmq/src/index.ts
@@ -128,6 +128,7 @@ export class RabbitMQTransport implements ITransport {
     await channel.assertExchange(SIGNAL_EXCHANGE, "topic", { durable: true });
 
     const content = this.serializeToBuffer({
+      v: 1,
       route,
       payload,
       op: "signal",

--- a/packages/transport-rabbitmq/src/rabbitmq-client.ts
+++ b/packages/transport-rabbitmq/src/rabbitmq-client.ts
@@ -69,6 +69,7 @@ export async function sendRpc(
 
   const serviceName = toServiceName(route);
   const body = serializeToBuffer(ctx.serializer, {
+    v: 1,
     route,
     payload,
     op,

--- a/packages/transport-rabbitmq/src/rabbitmq-feed.ts
+++ b/packages/transport-rabbitmq/src/rabbitmq-feed.ts
@@ -30,6 +30,7 @@ export async function publishFeed(
         runningFeed.exchange,
         "",
         serializeToBuffer({
+          v: 1,
           channel: "feed",
           feed: runningFeed.key,
           type: "next",
@@ -47,6 +48,7 @@ export async function publishFeed(
       runningFeed.exchange,
       "",
       serializeToBuffer({
+        v: 1,
         channel: "feed",
         feed: runningFeed.key,
         type: "done",
@@ -62,6 +64,7 @@ export async function publishFeed(
       runningFeed.exchange,
       "",
       serializeToBuffer({
+        v: 1,
         channel: "feed",
         feed: runningFeed.key,
         type: "error",

--- a/packages/transport-rabbitmq/src/rabbitmq-rpc.ts
+++ b/packages/transport-rabbitmq/src/rabbitmq-rpc.ts
@@ -131,6 +131,7 @@ export function replyWithPayload(ctx: RpcContext, message: ConsumeMessage, paylo
   ctx.getCurrentChannel()?.sendToQueue(
     replyTo,
     ctx.serializeToBuffer({
+      v: 1,
       payload,
     } satisfies ScompTransportResponseEnvelope),
     {
@@ -149,6 +150,7 @@ export function replyWithError(ctx: RpcContext, message: ConsumeMessage, error: 
   ctx.getCurrentChannel()?.sendToQueue(
     replyTo,
     ctx.serializeToBuffer({
+      v: 1,
       error: error instanceof Error ? error.message : String(error),
       code,
     } satisfies ScompTransportResponseEnvelope),

--- a/packages/transport-websocket-client/src/transport.ts
+++ b/packages/transport-websocket-client/src/transport.ts
@@ -296,6 +296,7 @@ export class WebSocketClientTransport implements ITransport {
 
     const outboundMeta = await this.composeOutboundMeta(options);
     const envelope: ScompTransportRequestEnvelope = {
+      v: 1,
       id,
       route,
       op,

--- a/packages/transport-websocket-server-runtime/src/index.ts
+++ b/packages/transport-websocket-server-runtime/src/index.ts
@@ -277,6 +277,7 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
     for (const socket of runningFeed.subscribers) {
       if (!this.config.isSocketOpen(socket)) continue;
       this.config.onFeedChunk(socket, {
+        v: 1,
         channel: "feed",
         ...chunk,
       } satisfies ScompFeedChunkEnvelope);
@@ -291,6 +292,7 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
   ): void {
     if (!id || !this.config.isSocketOpen(socket)) return;
     this.config.onReply(socket, {
+      v: 1,
       id,
       payload,
       meta,
@@ -306,6 +308,7 @@ export class WebSocketServerRuntime<Socket extends RuntimeSocket> {
   ): void {
     if (!id || !this.config.isSocketOpen(socket)) return;
     this.config.onReply(socket, {
+      v: 1,
       id,
       error: error instanceof Error ? error.message : String(error),
       code,

--- a/packages/types/src/protocol.ts
+++ b/packages/types/src/protocol.ts
@@ -132,6 +132,7 @@ export interface ScompTransportPrincipal {
 }
 
 export interface ScompTransportRequestEnvelope {
+  v?: number;
   id?: string;
   route: string;
   op: ScompTransportOperation;
@@ -144,6 +145,7 @@ export interface ScompTransportRequestEnvelope {
 export type ScompTransportRequest = ScompTransportRequestEnvelope;
 
 export interface ScompTransportSuccessResponseEnvelope {
+  v?: number;
   id?: string;
   payload?: unknown;
   meta?: ScompTransportMessageMeta;
@@ -169,6 +171,7 @@ export const SCOMP_ERROR_CODES: ReadonlyArray<ScompErrorCode> = [
 ] as const;
 
 export interface ScompTransportErrorResponseEnvelope {
+  v?: number;
   id?: string;
   error: string;
   code?: ScompErrorCode;
@@ -210,6 +213,7 @@ export type ScompControlPlaneSuccessResponse = {
 export type ScompFeedChunkType = "next" | "done" | "error";
 
 export interface ScompFeedChunkEnvelope {
+  v?: number;
   channel: "feed";
   feed: string;
   type: ScompFeedChunkType;


### PR DESCRIPTION
## Summary

Adds a `v: 1` protocol version field to all wire protocol envelopes before 0.1.0 publish. This provides future wire-breaking-change capability that's impossible to retrofit post-publish.

**Bead**: scomp-lon

### Changes
- `@scompr/types`: Added `v?: number` to all 4 envelope interfaces
- `@scompr/transport-websocket-client`: Sets `v: 1` on outgoing invoke requests
- `@scompr/transport-websocket-server-runtime`: Sets `v: 1` on replies and feed chunks
- `@scompr/transport-rabbitmq`: Sets `v: 1` on requests, responses, signals, and feed chunks

### Design
- `v` is **always set** on send (value: `1`)
- `v` is **optional** on receive (forward-compat: unknown versions ignored)
- Browser Windows and in-process transports excluded (no shared wire format)
- Purely additive — no behavioral change

### Verification
- Build: 13/13 ✅
- Lint: 12/12 ✅
- Tests: all green ✅